### PR TITLE
fix:折叠带左侧目录的回答时不显示脚本按钮UI

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -502,6 +502,8 @@ setTimeout(() => {
     .to-screenshot .zhihubackup-container{
         /*display: none;*/
     }
+
+    .RichContent.is-collapsed .zhihubackup-wrap,
     .RichContent:has(.ContentItem-more) .zhihubackup-wrap,
     .Post-RichTextContainer:has(.ContentItem-more) .zhihubackup-wrap{
         display:none;


### PR DESCRIPTION
  知乎对有目录的回答和普通回答的收起机制不同：

  
|                         | 普通回答               | 有目录的回答                      |
|-------------------------|------------------------|-----------------------------------|
| 收起时添加的标记        | .ContentItem-more 元素 | .RichContent 上加 is-collapsed 类 |
| .RichContent-inner 高度 | 变化                   | max-height: 400px                 |

  原有 CSS 只匹配 :has(.ContentItem-more)，目录回答永远不会出现这个元素，所以 UI在目录回答折叠时依然会出现
