### PR TITLE
feat: 支持侧边栏展开方式切换（悬停正文 / Chevron按钮）与极简模式体验优化

### DIFF
--- a/TampermonkeyConfig.js
+++ b/TampermonkeyConfig.js
@@ -30,6 +30,7 @@ export const UserScript = {
         "GM_setValue",
         "GM_getValue",
         "GM_registerMenuCommand",
-        "GM_unregisterMenuCommand"
+        "GM_unregisterMenuCommand",
+        "GM_setClipboard"
     ]
 }

--- a/dist/tampermonkey-script.js
+++ b/dist/tampermonkey-script.js
@@ -21,76 +21,38 @@
 // @grant        GM_getValue
 // @grant        GM_registerMenuCommand
 // @grant        GM_unregisterMenuCommand
+// @grant        GM_setClipboard
 // ==/UserScript==
-
-/** 
-## Changelog
-
-* 0.11.6（2026-02-01）:
-    - 修复有时候无法保存评论中链接的问题
-    - 修复无法保存想法中的用户的问题
-    - 修复突然无法输入备注的问题
-* 0.11.3（2025-12-04）:
-    - 修复一大堆关于公式的问题
-    - 修复脚注不能用的问题
-    - 跳过更多空白段落
-* 0.11.0（2025-12-03）:
-    - **可以保存内容到本地的指定目录**，便于分类，支持以多种格式保存
-    - 添加消息提示系统
-    - 样式和体验优化
-    - 删除无用的 info.json
-    - 为自定义保存文件名添加了默认值，方便修改
-    - 修复此问题：对于同一个内容，保存过 ZIP 后，评论中图片链接就永久变为本地链接，影响再次保存
-* 0.10.52（2025-10-08）:
-    - 修复知乎更新后无法保存想法中图片的问题
-* 0.10.51（202...
-...
-
- */
 
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 227:
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function(a,b){if(true)!(__WEBPACK_AMD_DEFINE_ARRAY__ = [], __WEBPACK_AMD_DEFINE_FACTORY__ = (b),
-		__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
-		(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
-		__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));else {}})(this,function(){"use strict";function b(a,b){return"undefined"==typeof b?b={autoBom:!1}:"object"!=typeof b&&(console.warn("Deprecated: Expected third argument to be a object"),b={autoBom:!b}),b.autoBom&&/^\s*(?:text\/\S*|application\/xml|\S*\/\S*\+xml)\s*;.*charset\s*=\s*utf-8/i.test(a.type)?new Blob(["\uFEFF",a],{type:a.type}):a}function c(a,b,c){var d=new XMLHttpRequest;d.open("GET",a),d.responseType="blob",d.onload=function(){g(d.response,b,c)},d.onerror=function(){console.error("could not download file")},d.send()}function d(a){var b=new XMLHttpRequest;b.open("HEAD",a,!1);try{b.send()}catch(a){}return 200<=b.status&&299>=b.status}function e(a){try{a.dispatchEvent(new MouseEvent("click"))}catch(c){var b=document.createEvent("MouseEvents");b.initMouseEvent("click",!0,!0,window,0,0,0,80,20,!1,!1,!1,!1,0,null),a.dispatchEvent(b)}}var f="object"==typeof window&&window.window===window?window:"object"==typeof self&&self.self===self?self:"object"==typeof __webpack_require__.g&&__webpack_require__.g.global===__webpack_require__.g?__webpack_require__.g:void 0,a=f.navigator&&/Macintosh/.test(navigator.userAgent)&&/AppleWebKit/.test(navigator.userAgent)&&!/Safari/.test(navigator.userAgent),g=f.saveAs||("object"!=typeof window||window!==f?function(){}:"download"in HTMLAnchorElement.prototype&&!a?function(b,g,h){var i=f.URL||f.webkitURL,j=document.createElement("a");g=g||b.name||"download",j.download=g,j.rel="noopener","string"==typeof b?(j.href=b,j.origin===location.origin?e(j):d(j.href)?c(b,g,h):e(j,j.target="_blank")):(j.href=i.createObjectURL(b),setTimeout(function(){i.revokeObjectURL(j.href)},4E4),setTimeout(function(){e(j)},0))}:"msSaveOrOpenBlob"in navigator?function(f,g,h){if(g=g||f.name||"download","string"!=typeof f)navigator.msSaveOrOpenBlob(b(f,h),g);else if(d(f))c(f,g,h);else{var i=document.createElement("a");i.href=f,i.target="_blank",setTimeout(function(){e(i)})}}:function(b,d,e,g){if(g=g||open("","_blank"),g&&(g.document.title=g.document.body.innerText="downloading..."),"string"==typeof b)return c(b,d,e);var h="application/octet-stream"===b.type,i=/constructor/i.test(f.HTMLElement)||f.safari,j=/CriOS\/[\d]+/.test(navigator.userAgent);if((j||h&&i||a)&&"undefined"!=typeof FileReader){var k=new FileReader;k.onloadend=function(){var a=k.result;a=j?a:a.replace(/^data:[^;]*;/,"data:attachment/file;"),g?g.location.href=a:location=a,g=null},k.readAsDataURL(b)}else{var l=f.URL||f.webkitURL,m=l.createObjectURL(b);g?g.location=m:location.href=m,g=null,setTimeout(function(){l.revokeObjectURL(m)},4E4)}});f.saveAs=g.saveAs=g, true&&(module.exports=g)});
-
-//# sourceMappingURL=FileSaver.min.js.map
-
-/***/ }),
-
-/***/ 434:
-/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+/***/ 1
+(module, __unused_webpack_exports, __webpack_require__) {
 
 /*!
 
-JSZip v3.9.1 - A JavaScript class for generating and reading zip files
+JSZip v3.10.1 - A JavaScript class for generating and reading zip files
 <http://stuartk.com/jszip>
 
 (c) 2009-2016 Stuart Knightley <stuart [at] stuartk.com>
-Dual licenced under the MIT license or GPLv3. See https://raw.github.com/Stuk/jszip/master/LICENSE.markdown.
+Dual licenced under the MIT license or GPLv3. See https://raw.github.com/Stuk/jszip/main/LICENSE.markdown.
 
 JSZip uses the library pako released under the MIT license :
-https://github.com/nodeca/pako/blob/master/LICENSE
+https://github.com/nodeca/pako/blob/main/LICENSE
 */
 
-!function(t){if(true)module.exports=t();else {}}(function(){return function s(a,o,h){function u(r,t){if(!o[r]){if(!a[r]){var e=undefined;if(!t&&e)return require(r,!0);if(l)return l(r,!0);var i=new Error("Cannot find module '"+r+"'");throw i.code="MODULE_NOT_FOUND",i}var n=o[r]={exports:{}};a[r][0].call(n.exports,function(t){var e=a[r][1][t];return u(e||t)},n,n.exports,s,a,o,h)}return o[r].exports}for(var l=undefined,t=0;t<h.length;t++)u(h[t]);return u}({1:[function(t,e,r){"use strict";var c=t("./utils"),d=t("./support"),p="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";r.encode=function(t){for(var e,r,i,n,s,a,o,h=[],u=0,l=t.length,f=l,d="string"!==c.getTypeOf(t);u<t.length;)f=l-u,i=d?(e=t[u++],r=u<l?t[u++]:0,u<l?t[u++]:0):(e=t.charCodeAt(u++),r=u<l?t.charCodeAt(u++):0,u<l?t.charCodeAt(u++):0),n=e>>2,s=(3&e)<<4|r>>4,a=1<f?(15&r)<<2|i>>6:64,o=2<f?63&i:64,h.push(p.charAt(n)+p.charAt(s)+p.charAt(a)+p.charAt(o));return h.join("")},r.decode=function(t){var e,r,i,n,s,a,o=0,h=0,u="data:";if(t.substr(0,u.length)===u)throw new Error("Invalid base64 input, it looks like a data url.");var l,f=3*(t=t.replace(/[^A-Za-z0-9\+\/\=]/g,"")).length/4;if(t.charAt(t.length-1)===p.charAt(64)&&f--,t.charAt(t.length-2)===p.charAt(64)&&f--,f%1!=0)throw new Error("Invalid base64 input, bad content length.");for(l=d.uint8array?new Uint8Array(0|f):new Array(0|f);o<t.length;)e=p.indexOf(t.charAt(o++))<<2|(n=p.indexOf(t.charAt(o++)))>>4,r=(15&n)<<4|(s=p.indexOf(t.charAt(o++)))>>2,i=(3&s)<<6|(a=p.indexOf(t.charAt(o++))),l[h++]=e,64!==s&&(l[h++]=r),64!==a&&(l[h++]=i);return l}},{"./support":30,"./utils":32}],2:[function(t,e,r){"use strict";var i=t("./external"),n=t("./stream/DataWorker"),s=t("./stream/Crc32Probe"),a=t("./stream/DataLengthProbe");function o(t,e,r,i,n){this.compressedSize=t,this.uncompressedSize=e,this.crc32=r,this.compression=i,this.compressedContent=n}o.prototype={getContentWorker:function(){var t=new n(i.Promise.resolve(this.compressedContent)).pipe(this.compression.uncompressWorker()).pipe(new a("data_length")),e=this;return t.on("end",function(){if(this.streamInfo.data_length!==e.uncompressedSize)throw new Error("Bug : uncompressed data size mismatch")}),t},getCompressedWorker:function(){return new n(i.Promise.resolve(this.compressedContent)).withStreamInfo("compressedSize",this.compressedSize).withStreamInfo("uncompressedSize",this.uncompressedSize).withStreamInfo("crc32",this.crc32).withStreamInfo("compression",this.compression)}},o.createWorkerFrom=function(t,e,r){return t.pipe(new s).pipe(new a("uncompressedSize")).pipe(e.compressWorker(r)).pipe(new a("compressedSize")).withStreamInfo("compression",e)},e.exports=o},{"./external":6,"./stream/Crc32Probe":25,"./stream/DataLengthProbe":26,"./stream/DataWorker":27}],3:[function(t,e,r){"use strict";var i=t("./stream/GenericWorker");r.STORE={magic:"\0\0",compressWorker:function(t){return new i("STORE compression")},uncompressWorker:function(){return new i("STORE decompression")}},r.DEFLATE=t("./flate")},{"./flate":7,"./stream/GenericWorker":28}],4:[function(t,e,r){"use strict";var i=t("./utils");var o=function(){for(var t,e=[],r=0;r<256;r++){t=r;for(var i=0;i<8;i++)t=1&t?3988292384^t>>>1:t>>>1;e[r]=t}return e}();e.exports=function(t,e){return void 0!==t&&t.length?"string"!==i.getTypeOf(t)?function(t,e,r,i){var n=o,s=i+r;t^=-1;for(var a=i;a<s;a++)t=t>>>8^n[255&(t^e[a])];return-1^t}(0|e,t,t.length,0):function(t,e,r,i){var n=o,s=i+r;t^=-1;for(var a=i;a<s;a++)t=t>>>8^n[255&(t^e.charCodeAt(a))];return-1^t}(0|e,t,t.length,0):0}},{"./utils":32}],5:[function(t,e,r){"use strict";r.base64=!1,r.binary=!1,r.dir=!1,r.createFolders=!0,r.date=null,r.compression=null,r.compressionOptions=null,r.comment=null,r.unixPermissions=null,r.dosPermissions=null},{}],6:[function(t,e,r){"use strict";var i=null;i="undefined"!=typeof Promise?Promise:t("lie"),e.exports={Promise:i}},{lie:37}],7:[function(t,e,r){"use strict";var i="undefined"!=typeof Uint8Array&&"undefined"!=typeof Uint16Array&&"undefined"!=typeof Uint32Array,n=t("pako"),s=t("./utils"),a=t("./stream/GenericWorker"),o=i?"uint8array":"array";function h(t,e){a.call(this,"FlateWorker/"+t),this._pako=null,this._pakoAction=t,this._pakoOptions=e,this.meta={}}r.magic="\b\0",s.inherits(h,a),h.prototype.processChunk=function(t){this.meta=t.meta,null===this._pako&&this._createPako(),this._pako.push(s.transformTo(o,t.data),!1)},h.prototype.flush=function(){a.prototype.flush.call(this),null===this._pako&&this._createPako(),this._pako.push([],!0)},h.prototype.cleanUp=function(){a.prototype.cleanUp.call(this),this._pako=null},h.prototype._createPako=function(){this._pako=new n[this._pakoAction]({raw:!0,level:this._pakoOptions.level||-1});var e=this;this._pako.onData=function(t){e.push({data:t,meta:e.meta})}},r.compressWorker=function(t){return new h("Deflate",t)},r.uncompressWorker=function(){return new h("Inflate",{})}},{"./stream/GenericWorker":28,"./utils":32,pako:38}],8:[function(t,e,r){"use strict";function A(t,e){var r,i="";for(r=0;r<e;r++)i+=String.fromCharCode(255&t),t>>>=8;return i}function i(t,e,r,i,n,s){var a,o,h=t.file,u=t.compression,l=s!==O.utf8encode,f=I.transformTo("string",s(h.name)),d=I.transformTo("string",O.utf8encode(h.name)),c=h.comment,p=I.transformTo("string",s(c)),m=I.transformTo("string",O.utf8encode(c)),_=d.length!==h.name.length,g=m.length!==c.length,b="",v="",y="",w=h.dir,k=h.date,x={crc32:0,compressedSize:0,uncompressedSize:0};e&&!r||(x.crc32=t.crc32,x.compressedSize=t.compressedSize,x.uncompressedSize=t.uncompressedSize);var S=0;e&&(S|=8),l||!_&&!g||(S|=2048);var z=0,C=0;w&&(z|=16),"UNIX"===n?(C=798,z|=function(t,e){var r=t;return t||(r=e?16893:33204),(65535&r)<<16}(h.unixPermissions,w)):(C=20,z|=function(t){return 63&(t||0)}(h.dosPermissions)),a=k.getHours(),a<<=6,a|=k.getMinutes(),a<<=5,a|=k.getSeconds()/2,o=k.getFullYear()-1980,o<<=4,o|=k.getMonth()+1,o<<=5,o|=k.getDate(),_&&(v=A(1,1)+A(B(f),4)+d,b+="up"+A(v.length,2)+v),g&&(y=A(1,1)+A(B(p),4)+m,b+="uc"+A(y.length,2)+y);var E="";return E+="\n\0",E+=A(S,2),E+=u.magic,E+=A(a,2),E+=A(o,2),E+=A(x.crc32,4),E+=A(x.compressedSize,4),E+=A(x.uncompressedSize,4),E+=A(f.length,2),E+=A(b.length,2),{fileRecord:R.LOCAL_FILE_HEADER+E+f+b,dirRecord:R.CENTRAL_FILE_HEADER+A(C,2)+E+A(p.length,2)+"\0\0\0\0"+A(z,4)+A(i,4)+f+b+p}}var I=t("../utils"),n=t("../stream/GenericWorker"),O=t("../utf8"),B=t("../crc32"),R=t("../signature");function s(t,e,r,i){n.call(this,"ZipFileWorker"),this.bytesWritten=0,this.zipComment=e,this.zipPlatform=r,this.encodeFileName=i,this.streamFiles=t,this.accumulate=!1,this.contentBuffer=[],this.dirRecords=[],this.currentSourceOffset=0,this.entriesCount=0,this.currentFile=null,this._sources=[]}I.inherits(s,n),s.prototype.push=function(t){var e=t.meta.percent||0,r=this.entriesCount,i=this._sources.length;this.accumulate?this.contentBuffer.push(t):(this.bytesWritten+=t.data.length,n.prototype.push.call(this,{data:t.data,meta:{currentFile:this.currentFile,percent:r?(e+100*(r-i-1))/r:100}}))},s.prototype.openedSource=function(t){this.currentSourceOffset=this.bytesWritten,this.currentFile=t.file.name;var e=this.streamFiles&&!t.file.dir;if(e){var r=i(t,e,!1,this.currentSourceOffset,this.zipPlatform,this.encodeFileName);this.push({data:r.fileRecord,meta:{percent:0}})}else this.accumulate=!0},s.prototype.closedSource=function(t){this.accumulate=!1;var e=this.streamFiles&&!t.file.dir,r=i(t,e,!0,this.currentSourceOffset,this.zipPlatform,this.encodeFileName);if(this.dirRecords.push(r.dirRecord),e)this.push({data:function(t){return R.DATA_DESCRIPTOR+A(t.crc32,4)+A(t.compressedSize,4)+A(t.uncompressedSize,4)}(t),meta:{percent:100}});else for(this.push({data:r.fileRecord,meta:{percent:0}});this.contentBuffer.length;)this.push(this.contentBuffer.shift());this.currentFile=null},s.prototype.flush=function(){for(var t=this.bytesWritten,e=0;e<this.dirRecords.length;e++)this.push({data:this.dirRecords[e],meta:{percent:100}});var r=this.bytesWritten-t,i=function(t,e,r,i,n){var s=I.transformTo("string",n(i));return R.CENTRAL_DIRECTORY_END+"\0\0\0\0"+A(t,2)+A(t,2)+A(e,4)+A(r,4)+A(s.length,2)+s}(this.dirRecords.length,r,t,this.zipComment,this.encodeFileName);this.push({data:i,meta:{percent:100}})},s.prototype.prepareNextSource=function(){this.previous=this._sources.shift(),this.openedSource(this.previous.streamInfo),this.isPaused?this.previous.pause():this.previous.resume()},s.prototype.registerPrevious=function(t){this._sources.push(t);var e=this;return t.on("data",function(t){e.processChunk(t)}),t.on("end",function(){e.closedSource(e.previous.streamInfo),e._sources.length?e.prepareNextSource():e.end()}),t.on("error",function(t){e.error(t)}),this},s.prototype.resume=function(){return!!n.prototype.resume.call(this)&&(!this.previous&&this._sources.length?(this.prepareNextSource(),!0):this.previous||this._sources.length||this.generatedError?void 0:(this.end(),!0))},s.prototype.error=function(t){var e=this._sources;if(!n.prototype.error.call(this,t))return!1;for(var r=0;r<e.length;r++)try{e[r].error(t)}catch(t){}return!0},s.prototype.lock=function(){n.prototype.lock.call(this);for(var t=this._sources,e=0;e<t.length;e++)t[e].lock()},e.exports=s},{"../crc32":4,"../signature":23,"../stream/GenericWorker":28,"../utf8":31,"../utils":32}],9:[function(t,e,r){"use strict";var u=t("../compressions"),i=t("./ZipFileWorker");r.generateWorker=function(t,a,e){var o=new i(a.streamFiles,e,a.platform,a.encodeFileName),h=0;try{t.forEach(function(t,e){h++;var r=function(t,e){var r=t||e,i=u[r];if(!i)throw new Error(r+" is not a valid compression method !");return i}(e.options.compression,a.compression),i=e.options.compressionOptions||a.compressionOptions||{},n=e.dir,s=e.date;e._compressWorker(r,i).withStreamInfo("file",{name:t,dir:n,date:s,comment:e.comment||"",unixPermissions:e.unixPermissions,dosPermissions:e.dosPermissions}).pipe(o)}),o.entriesCount=h}catch(t){o.error(t)}return o}},{"../compressions":3,"./ZipFileWorker":8}],10:[function(t,e,r){"use strict";function i(){if(!(this instanceof i))return new i;if(arguments.length)throw new Error("The constructor with parameters has been removed in JSZip 3.0, please check the upgrade guide.");this.files=Object.create(null),this.comment=null,this.root="",this.clone=function(){var t=new i;for(var e in this)"function"!=typeof this[e]&&(t[e]=this[e]);return t}}(i.prototype=t("./object")).loadAsync=t("./load"),i.support=t("./support"),i.defaults=t("./defaults"),i.version="3.9.1",i.loadAsync=function(t,e){return(new i).loadAsync(t,e)},i.external=t("./external"),e.exports=i},{"./defaults":5,"./external":6,"./load":11,"./object":15,"./support":30}],11:[function(t,e,r){"use strict";var u=t("./utils"),n=t("./external"),i=t("./utf8"),s=t("./zipEntries"),a=t("./stream/Crc32Probe"),l=t("./nodejsUtils");function f(i){return new n.Promise(function(t,e){var r=i.decompressed.getContentWorker().pipe(new a);r.on("error",function(t){e(t)}).on("end",function(){r.streamInfo.crc32!==i.decompressed.crc32?e(new Error("Corrupted zip : CRC32 mismatch")):t()}).resume()})}e.exports=function(t,o){var h=this;return o=u.extend(o||{},{base64:!1,checkCRC32:!1,optimizedBinaryString:!1,createFolders:!1,decodeFileName:i.utf8decode}),l.isNode&&l.isStream(t)?n.Promise.reject(new Error("JSZip can't accept a stream when loading a zip file.")):u.prepareContent("the loaded zip file",t,!0,o.optimizedBinaryString,o.base64).then(function(t){var e=new s(o);return e.load(t),e}).then(function(t){var e=[n.Promise.resolve(t)],r=t.files;if(o.checkCRC32)for(var i=0;i<r.length;i++)e.push(f(r[i]));return n.Promise.all(e)}).then(function(t){for(var e=t.shift(),r=e.files,i=0;i<r.length;i++){var n=r[i],s=n.fileNameStr,a=u.resolve(n.fileNameStr);h.file(a,n.decompressed,{binary:!0,optimizedBinaryString:!0,date:n.date,dir:n.dir,comment:n.fileCommentStr.length?n.fileCommentStr:null,unixPermissions:n.unixPermissions,dosPermissions:n.dosPermissions,createFolders:o.createFolders}),n.dir||(h.file(a).unsafeOriginalName=s)}return e.zipComment.length&&(h.comment=e.zipComment),h})}},{"./external":6,"./nodejsUtils":14,"./stream/Crc32Probe":25,"./utf8":31,"./utils":32,"./zipEntries":33}],12:[function(t,e,r){"use strict";var i=t("../utils"),n=t("../stream/GenericWorker");function s(t,e){n.call(this,"Nodejs stream input adapter for "+t),this._upstreamEnded=!1,this._bindStream(e)}i.inherits(s,n),s.prototype._bindStream=function(t){var e=this;(this._stream=t).pause(),t.on("data",function(t){e.push({data:t,meta:{percent:0}})}).on("error",function(t){e.isPaused?this.generatedError=t:e.error(t)}).on("end",function(){e.isPaused?e._upstreamEnded=!0:e.end()})},s.prototype.pause=function(){return!!n.prototype.pause.call(this)&&(this._stream.pause(),!0)},s.prototype.resume=function(){return!!n.prototype.resume.call(this)&&(this._upstreamEnded?this.end():this._stream.resume(),!0)},e.exports=s},{"../stream/GenericWorker":28,"../utils":32}],13:[function(t,e,r){"use strict";var n=t("readable-stream").Readable;function i(t,e,r){n.call(this,e),this._helper=t;var i=this;t.on("data",function(t,e){i.push(t)||i._helper.pause(),r&&r(e)}).on("error",function(t){i.emit("error",t)}).on("end",function(){i.push(null)})}t("../utils").inherits(i,n),i.prototype._read=function(){this._helper.resume()},e.exports=i},{"../utils":32,"readable-stream":16}],14:[function(t,e,r){"use strict";e.exports={isNode:"undefined"!=typeof Buffer,newBufferFrom:function(t,e){if(Buffer.from&&Buffer.from!==Uint8Array.from)return Buffer.from(t,e);if("number"==typeof t)throw new Error('The "data" argument must not be a number');return new Buffer(t,e)},allocBuffer:function(t){if(Buffer.alloc)return Buffer.alloc(t);var e=new Buffer(t);return e.fill(0),e},isBuffer:function(t){return Buffer.isBuffer(t)},isStream:function(t){return t&&"function"==typeof t.on&&"function"==typeof t.pause&&"function"==typeof t.resume}}},{}],15:[function(t,e,r){"use strict";function s(t,e,r){var i,n=u.getTypeOf(e),s=u.extend(r||{},f);s.date=s.date||new Date,null!==s.compression&&(s.compression=s.compression.toUpperCase()),"string"==typeof s.unixPermissions&&(s.unixPermissions=parseInt(s.unixPermissions,8)),s.unixPermissions&&16384&s.unixPermissions&&(s.dir=!0),s.dosPermissions&&16&s.dosPermissions&&(s.dir=!0),s.dir&&(t=g(t)),s.createFolders&&(i=_(t))&&b.call(this,i,!0);var a="string"===n&&!1===s.binary&&!1===s.base64;r&&void 0!==r.binary||(s.binary=!a),(e instanceof d&&0===e.uncompressedSize||s.dir||!e||0===e.length)&&(s.base64=!1,s.binary=!0,e="",s.compression="STORE",n="string");var o=null;o=e instanceof d||e instanceof l?e:p.isNode&&p.isStream(e)?new m(t,e):u.prepareContent(t,e,s.binary,s.optimizedBinaryString,s.base64);var h=new c(t,o,s);this.files[t]=h}var n=t("./utf8"),u=t("./utils"),l=t("./stream/GenericWorker"),a=t("./stream/StreamHelper"),f=t("./defaults"),d=t("./compressedObject"),c=t("./zipObject"),o=t("./generate"),p=t("./nodejsUtils"),m=t("./nodejs/NodejsStreamInputAdapter"),_=function(t){"/"===t.slice(-1)&&(t=t.substring(0,t.length-1));var e=t.lastIndexOf("/");return 0<e?t.substring(0,e):""},g=function(t){return"/"!==t.slice(-1)&&(t+="/"),t},b=function(t,e){return e=void 0!==e?e:f.createFolders,t=g(t),this.files[t]||s.call(this,t,null,{dir:!0,createFolders:e}),this.files[t]};function h(t){return"[object RegExp]"===Object.prototype.toString.call(t)}var i={load:function(){throw new Error("This method has been removed in JSZip 3.0, please check the upgrade guide.")},forEach:function(t){var e,r,i;for(e in this.files)i=this.files[e],(r=e.slice(this.root.length,e.length))&&e.slice(0,this.root.length)===this.root&&t(r,i)},filter:function(r){var i=[];return this.forEach(function(t,e){r(t,e)&&i.push(e)}),i},file:function(t,e,r){if(1!==arguments.length)return t=this.root+t,s.call(this,t,e,r),this;if(h(t)){var i=t;return this.filter(function(t,e){return!e.dir&&i.test(t)})}var n=this.files[this.root+t];return n&&!n.dir?n:null},folder:function(r){if(!r)return this;if(h(r))return this.filter(function(t,e){return e.dir&&r.test(t)});var t=this.root+r,e=b.call(this,t),i=this.clone();return i.root=e.name,i},remove:function(r){r=this.root+r;var t=this.files[r];if(t||("/"!==r.slice(-1)&&(r+="/"),t=this.files[r]),t&&!t.dir)delete this.files[r];else for(var e=this.filter(function(t,e){return e.name.slice(0,r.length)===r}),i=0;i<e.length;i++)delete this.files[e[i].name];return this},generate:function(t){throw new Error("This method has been removed in JSZip 3.0, please check the upgrade guide.")},generateInternalStream:function(t){var e,r={};try{if((r=u.extend(t||{},{streamFiles:!1,compression:"STORE",compressionOptions:null,type:"",platform:"DOS",comment:null,mimeType:"application/zip",encodeFileName:n.utf8encode})).type=r.type.toLowerCase(),r.compression=r.compression.toUpperCase(),"binarystring"===r.type&&(r.type="string"),!r.type)throw new Error("No output type specified.");u.checkSupport(r.type),"darwin"!==r.platform&&"freebsd"!==r.platform&&"linux"!==r.platform&&"sunos"!==r.platform||(r.platform="UNIX"),"win32"===r.platform&&(r.platform="DOS");var i=r.comment||this.comment||"";e=o.generateWorker(this,r,i)}catch(t){(e=new l("error")).error(t)}return new a(e,r.type||"string",r.mimeType)},generateAsync:function(t,e){return this.generateInternalStream(t).accumulate(e)},generateNodeStream:function(t,e){return(t=t||{}).type||(t.type="nodebuffer"),this.generateInternalStream(t).toNodejsStream(e)}};e.exports=i},{"./compressedObject":2,"./defaults":5,"./generate":9,"./nodejs/NodejsStreamInputAdapter":12,"./nodejsUtils":14,"./stream/GenericWorker":28,"./stream/StreamHelper":29,"./utf8":31,"./utils":32,"./zipObject":35}],16:[function(t,e,r){e.exports=t("stream")},{stream:void 0}],17:[function(t,e,r){"use strict";var i=t("./DataReader");function n(t){i.call(this,t);for(var e=0;e<this.data.length;e++)t[e]=255&t[e]}t("../utils").inherits(n,i),n.prototype.byteAt=function(t){return this.data[this.zero+t]},n.prototype.lastIndexOfSignature=function(t){for(var e=t.charCodeAt(0),r=t.charCodeAt(1),i=t.charCodeAt(2),n=t.charCodeAt(3),s=this.length-4;0<=s;--s)if(this.data[s]===e&&this.data[s+1]===r&&this.data[s+2]===i&&this.data[s+3]===n)return s-this.zero;return-1},n.prototype.readAndCheckSignature=function(t){var e=t.charCodeAt(0),r=t.charCodeAt(1),i=t.charCodeAt(2),n=t.charCodeAt(3),s=this.readData(4);return e===s[0]&&r===s[1]&&i===s[2]&&n===s[3]},n.prototype.readData=function(t){if(this.checkOffset(t),0===t)return[];var e=this.data.slice(this.zero+this.index,this.zero+this.index+t);return this.index+=t,e},e.exports=n},{"../utils":32,"./DataReader":18}],18:[function(t,e,r){"use strict";var i=t("../utils");function n(t){this.data=t,this.length=t.length,this.index=0,this.zero=0}n.prototype={checkOffset:function(t){this.checkIndex(this.index+t)},checkIndex:function(t){if(this.length<this.zero+t||t<0)throw new Error("End of data reached (data length = "+this.length+", asked index = "+t+"). Corrupted zip ?")},setIndex:function(t){this.checkIndex(t),this.index=t},skip:function(t){this.setIndex(this.index+t)},byteAt:function(t){},readInt:function(t){var e,r=0;for(this.checkOffset(t),e=this.index+t-1;e>=this.index;e--)r=(r<<8)+this.byteAt(e);return this.index+=t,r},readString:function(t){return i.transformTo("string",this.readData(t))},readData:function(t){},lastIndexOfSignature:function(t){},readAndCheckSignature:function(t){},readDate:function(){var t=this.readInt(4);return new Date(1980+(t>>25&127),(t>>21&15)-1,t>>16&31,t>>11&31,t>>5&63,(31&t)<<1)}},e.exports=n},{"../utils":32}],19:[function(t,e,r){"use strict";var i=t("./Uint8ArrayReader");function n(t){i.call(this,t)}t("../utils").inherits(n,i),n.prototype.readData=function(t){this.checkOffset(t);var e=this.data.slice(this.zero+this.index,this.zero+this.index+t);return this.index+=t,e},e.exports=n},{"../utils":32,"./Uint8ArrayReader":21}],20:[function(t,e,r){"use strict";var i=t("./DataReader");function n(t){i.call(this,t)}t("../utils").inherits(n,i),n.prototype.byteAt=function(t){return this.data.charCodeAt(this.zero+t)},n.prototype.lastIndexOfSignature=function(t){return this.data.lastIndexOf(t)-this.zero},n.prototype.readAndCheckSignature=function(t){return t===this.readData(4)},n.prototype.readData=function(t){this.checkOffset(t);var e=this.data.slice(this.zero+this.index,this.zero+this.index+t);return this.index+=t,e},e.exports=n},{"../utils":32,"./DataReader":18}],21:[function(t,e,r){"use strict";var i=t("./ArrayReader");function n(t){i.call(this,t)}t("../utils").inherits(n,i),n.prototype.readData=function(t){if(this.checkOffset(t),0===t)return new Uint8Array(0);var e=this.data.subarray(this.zero+this.index,this.zero+this.index+t);return this.index+=t,e},e.exports=n},{"../utils":32,"./ArrayReader":17}],22:[function(t,e,r){"use strict";var i=t("../utils"),n=t("../support"),s=t("./ArrayReader"),a=t("./StringReader"),o=t("./NodeBufferReader"),h=t("./Uint8ArrayReader");e.exports=function(t){var e=i.getTypeOf(t);return i.checkSupport(e),"string"!==e||n.uint8array?"nodebuffer"===e?new o(t):n.uint8array?new h(i.transformTo("uint8array",t)):new s(i.transformTo("array",t)):new a(t)}},{"../support":30,"../utils":32,"./ArrayReader":17,"./NodeBufferReader":19,"./StringReader":20,"./Uint8ArrayReader":21}],23:[function(t,e,r){"use strict";r.LOCAL_FILE_HEADER="PK",r.CENTRAL_FILE_HEADER="PK",r.CENTRAL_DIRECTORY_END="PK",r.ZIP64_CENTRAL_DIRECTORY_LOCATOR="PK",r.ZIP64_CENTRAL_DIRECTORY_END="PK",r.DATA_DESCRIPTOR="PK\b"},{}],24:[function(t,e,r){"use strict";var i=t("./GenericWorker"),n=t("../utils");function s(t){i.call(this,"ConvertWorker to "+t),this.destType=t}n.inherits(s,i),s.prototype.processChunk=function(t){this.push({data:n.transformTo(this.destType,t.data),meta:t.meta})},e.exports=s},{"../utils":32,"./GenericWorker":28}],25:[function(t,e,r){"use strict";var i=t("./GenericWorker"),n=t("../crc32");function s(){i.call(this,"Crc32Probe"),this.withStreamInfo("crc32",0)}t("../utils").inherits(s,i),s.prototype.processChunk=function(t){this.streamInfo.crc32=n(t.data,this.streamInfo.crc32||0),this.push(t)},e.exports=s},{"../crc32":4,"../utils":32,"./GenericWorker":28}],26:[function(t,e,r){"use strict";var i=t("../utils"),n=t("./GenericWorker");function s(t){n.call(this,"DataLengthProbe for "+t),this.propName=t,this.withStreamInfo(t,0)}i.inherits(s,n),s.prototype.processChunk=function(t){if(t){var e=this.streamInfo[this.propName]||0;this.streamInfo[this.propName]=e+t.data.length}n.prototype.processChunk.call(this,t)},e.exports=s},{"../utils":32,"./GenericWorker":28}],27:[function(t,e,r){"use strict";var i=t("../utils"),n=t("./GenericWorker");function s(t){n.call(this,"DataWorker");var e=this;this.dataIsReady=!1,this.index=0,this.max=0,this.data=null,this.type="",this._tickScheduled=!1,t.then(function(t){e.dataIsReady=!0,e.data=t,e.max=t&&t.length||0,e.type=i.getTypeOf(t),e.isPaused||e._tickAndRepeat()},function(t){e.error(t)})}i.inherits(s,n),s.prototype.cleanUp=function(){n.prototype.cleanUp.call(this),this.data=null},s.prototype.resume=function(){return!!n.prototype.resume.call(this)&&(!this._tickScheduled&&this.dataIsReady&&(this._tickScheduled=!0,i.delay(this._tickAndRepeat,[],this)),!0)},s.prototype._tickAndRepeat=function(){this._tickScheduled=!1,this.isPaused||this.isFinished||(this._tick(),this.isFinished||(i.delay(this._tickAndRepeat,[],this),this._tickScheduled=!0))},s.prototype._tick=function(){if(this.isPaused||this.isFinished)return!1;var t=null,e=Math.min(this.max,this.index+16384);if(this.index>=this.max)return this.end();switch(this.type){case"string":t=this.data.substring(this.index,e);break;case"uint8array":t=this.data.subarray(this.index,e);break;case"array":case"nodebuffer":t=this.data.slice(this.index,e)}return this.index=e,this.push({data:t,meta:{percent:this.max?this.index/this.max*100:0}})},e.exports=s},{"../utils":32,"./GenericWorker":28}],28:[function(t,e,r){"use strict";function i(t){this.name=t||"default",this.streamInfo={},this.generatedError=null,this.extraStreamInfo={},this.isPaused=!0,this.isFinished=!1,this.isLocked=!1,this._listeners={data:[],end:[],error:[]},this.previous=null}i.prototype={push:function(t){this.emit("data",t)},end:function(){if(this.isFinished)return!1;this.flush();try{this.emit("end"),this.cleanUp(),this.isFinished=!0}catch(t){this.emit("error",t)}return!0},error:function(t){return!this.isFinished&&(this.isPaused?this.generatedError=t:(this.isFinished=!0,this.emit("error",t),this.previous&&this.previous.error(t),this.cleanUp()),!0)},on:function(t,e){return this._listeners[t].push(e),this},cleanUp:function(){this.streamInfo=this.generatedError=this.extraStreamInfo=null,this._listeners=[]},emit:function(t,e){if(this._listeners[t])for(var r=0;r<this._listeners[t].length;r++)this._listeners[t][r].call(this,e)},pipe:function(t){return t.registerPrevious(this)},registerPrevious:function(t){if(this.isLocked)throw new Error("The stream '"+this+"' has already been used.");this.streamInfo=t.streamInfo,this.mergeStreamInfo(),this.previous=t;var e=this;return t.on("data",function(t){e.processChunk(t)}),t.on("end",function(){e.end()}),t.on("error",function(t){e.error(t)}),this},pause:function(){return!this.isPaused&&!this.isFinished&&(this.isPaused=!0,this.previous&&this.previous.pause(),!0)},resume:function(){if(!this.isPaused||this.isFinished)return!1;var t=this.isPaused=!1;return this.generatedError&&(this.error(this.generatedError),t=!0),this.previous&&this.previous.resume(),!t},flush:function(){},processChunk:function(t){this.push(t)},withStreamInfo:function(t,e){return this.extraStreamInfo[t]=e,this.mergeStreamInfo(),this},mergeStreamInfo:function(){for(var t in this.extraStreamInfo)this.extraStreamInfo.hasOwnProperty(t)&&(this.streamInfo[t]=this.extraStreamInfo[t])},lock:function(){if(this.isLocked)throw new Error("The stream '"+this+"' has already been used.");this.isLocked=!0,this.previous&&this.previous.lock()},toString:function(){var t="Worker "+this.name;return this.previous?this.previous+" -> "+t:t}},e.exports=i},{}],29:[function(t,e,r){"use strict";var h=t("../utils"),n=t("./ConvertWorker"),s=t("./GenericWorker"),u=t("../base64"),i=t("../support"),a=t("../external"),o=null;if(i.nodestream)try{o=t("../nodejs/NodejsStreamOutputAdapter")}catch(t){}function l(t,o){return new a.Promise(function(e,r){var i=[],n=t._internalType,s=t._outputType,a=t._mimeType;t.on("data",function(t,e){i.push(t),o&&o(e)}).on("error",function(t){i=[],r(t)}).on("end",function(){try{var t=function(t,e,r){switch(t){case"blob":return h.newBlob(h.transformTo("arraybuffer",e),r);case"base64":return u.encode(e);default:return h.transformTo(t,e)}}(s,function(t,e){var r,i=0,n=null,s=0;for(r=0;r<e.length;r++)s+=e[r].length;switch(t){case"string":return e.join("");case"array":return Array.prototype.concat.apply([],e);case"uint8array":for(n=new Uint8Array(s),r=0;r<e.length;r++)n.set(e[r],i),i+=e[r].length;return n;case"nodebuffer":return Buffer.concat(e);default:throw new Error("concat : unsupported type '"+t+"'")}}(n,i),a);e(t)}catch(t){r(t)}i=[]}).resume()})}function f(t,e,r){var i=e;switch(e){case"blob":case"arraybuffer":i="uint8array";break;case"base64":i="string"}try{this._internalType=i,this._outputType=e,this._mimeType=r,h.checkSupport(i),this._worker=t.pipe(new n(i)),t.lock()}catch(t){this._worker=new s("error"),this._worker.error(t)}}f.prototype={accumulate:function(t){return l(this,t)},on:function(t,e){var r=this;return"data"===t?this._worker.on(t,function(t){e.call(r,t.data,t.meta)}):this._worker.on(t,function(){h.delay(e,arguments,r)}),this},resume:function(){return h.delay(this._worker.resume,[],this._worker),this},pause:function(){return this._worker.pause(),this},toNodejsStream:function(t){if(h.checkSupport("nodestream"),"nodebuffer"!==this._outputType)throw new Error(this._outputType+" is not supported by this method");return new o(this,{objectMode:"nodebuffer"!==this._outputType},t)}},e.exports=f},{"../base64":1,"../external":6,"../nodejs/NodejsStreamOutputAdapter":13,"../support":30,"../utils":32,"./ConvertWorker":24,"./GenericWorker":28}],30:[function(t,e,r){"use strict";if(r.base64=!0,r.array=!0,r.string=!0,r.arraybuffer="undefined"!=typeof ArrayBuffer&&"undefined"!=typeof Uint8Array,r.nodebuffer="undefined"!=typeof Buffer,r.uint8array="undefined"!=typeof Uint8Array,"undefined"==typeof ArrayBuffer)r.blob=!1;else{var i=new ArrayBuffer(0);try{r.blob=0===new Blob([i],{type:"application/zip"}).size}catch(t){try{var n=new(self.BlobBuilder||self.WebKitBlobBuilder||self.MozBlobBuilder||self.MSBlobBuilder);n.append(i),r.blob=0===n.getBlob("application/zip").size}catch(t){r.blob=!1}}}try{r.nodestream=!!t("readable-stream").Readable}catch(t){r.nodestream=!1}},{"readable-stream":16}],31:[function(t,e,s){"use strict";for(var o=t("./utils"),h=t("./support"),r=t("./nodejsUtils"),i=t("./stream/GenericWorker"),u=new Array(256),n=0;n<256;n++)u[n]=252<=n?6:248<=n?5:240<=n?4:224<=n?3:192<=n?2:1;u[254]=u[254]=1;function a(){i.call(this,"utf-8 decode"),this.leftOver=null}function l(){i.call(this,"utf-8 encode")}s.utf8encode=function(t){return h.nodebuffer?r.newBufferFrom(t,"utf-8"):function(t){var e,r,i,n,s,a=t.length,o=0;for(n=0;n<a;n++)55296==(64512&(r=t.charCodeAt(n)))&&n+1<a&&56320==(64512&(i=t.charCodeAt(n+1)))&&(r=65536+(r-55296<<10)+(i-56320),n++),o+=r<128?1:r<2048?2:r<65536?3:4;for(e=h.uint8array?new Uint8Array(o):new Array(o),n=s=0;s<o;n++)55296==(64512&(r=t.charCodeAt(n)))&&n+1<a&&56320==(64512&(i=t.charCodeAt(n+1)))&&(r=65536+(r-55296<<10)+(i-56320),n++),r<128?e[s++]=r:(r<2048?e[s++]=192|r>>>6:(r<65536?e[s++]=224|r>>>12:(e[s++]=240|r>>>18,e[s++]=128|r>>>12&63),e[s++]=128|r>>>6&63),e[s++]=128|63&r);return e}(t)},s.utf8decode=function(t){return h.nodebuffer?o.transformTo("nodebuffer",t).toString("utf-8"):function(t){var e,r,i,n,s=t.length,a=new Array(2*s);for(e=r=0;e<s;)if((i=t[e++])<128)a[r++]=i;else if(4<(n=u[i]))a[r++]=65533,e+=n-1;else{for(i&=2===n?31:3===n?15:7;1<n&&e<s;)i=i<<6|63&t[e++],n--;1<n?a[r++]=65533:i<65536?a[r++]=i:(i-=65536,a[r++]=55296|i>>10&1023,a[r++]=56320|1023&i)}return a.length!==r&&(a.subarray?a=a.subarray(0,r):a.length=r),o.applyFromCharCode(a)}(t=o.transformTo(h.uint8array?"uint8array":"array",t))},o.inherits(a,i),a.prototype.processChunk=function(t){var e=o.transformTo(h.uint8array?"uint8array":"array",t.data);if(this.leftOver&&this.leftOver.length){if(h.uint8array){var r=e;(e=new Uint8Array(r.length+this.leftOver.length)).set(this.leftOver,0),e.set(r,this.leftOver.length)}else e=this.leftOver.concat(e);this.leftOver=null}var i=function(t,e){var r;for((e=e||t.length)>t.length&&(e=t.length),r=e-1;0<=r&&128==(192&t[r]);)r--;return r<0?e:0===r?e:r+u[t[r]]>e?r:e}(e),n=e;i!==e.length&&(h.uint8array?(n=e.subarray(0,i),this.leftOver=e.subarray(i,e.length)):(n=e.slice(0,i),this.leftOver=e.slice(i,e.length))),this.push({data:s.utf8decode(n),meta:t.meta})},a.prototype.flush=function(){this.leftOver&&this.leftOver.length&&(this.push({data:s.utf8decode(this.leftOver),meta:{}}),this.leftOver=null)},s.Utf8DecodeWorker=a,o.inherits(l,i),l.prototype.processChunk=function(t){this.push({data:s.utf8encode(t.data),meta:t.meta})},s.Utf8EncodeWorker=l},{"./nodejsUtils":14,"./stream/GenericWorker":28,"./support":30,"./utils":32}],32:[function(t,e,a){"use strict";var o=t("./support"),h=t("./base64"),r=t("./nodejsUtils"),i=t("set-immediate-shim"),u=t("./external");function n(t){return t}function l(t,e){for(var r=0;r<t.length;++r)e[r]=255&t.charCodeAt(r);return e}a.newBlob=function(e,r){a.checkSupport("blob");try{return new Blob([e],{type:r})}catch(t){try{var i=new(self.BlobBuilder||self.WebKitBlobBuilder||self.MozBlobBuilder||self.MSBlobBuilder);return i.append(e),i.getBlob(r)}catch(t){throw new Error("Bug : can't construct the Blob.")}}};var s={stringifyByChunk:function(t,e,r){var i=[],n=0,s=t.length;if(s<=r)return String.fromCharCode.apply(null,t);for(;n<s;)"array"===e||"nodebuffer"===e?i.push(String.fromCharCode.apply(null,t.slice(n,Math.min(n+r,s)))):i.push(String.fromCharCode.apply(null,t.subarray(n,Math.min(n+r,s)))),n+=r;return i.join("")},stringifyByChar:function(t){for(var e="",r=0;r<t.length;r++)e+=String.fromCharCode(t[r]);return e},applyCanBeUsed:{uint8array:function(){try{return o.uint8array&&1===String.fromCharCode.apply(null,new Uint8Array(1)).length}catch(t){return!1}}(),nodebuffer:function(){try{return o.nodebuffer&&1===String.fromCharCode.apply(null,r.allocBuffer(1)).length}catch(t){return!1}}()}};function f(t){var e=65536,r=a.getTypeOf(t),i=!0;if("uint8array"===r?i=s.applyCanBeUsed.uint8array:"nodebuffer"===r&&(i=s.applyCanBeUsed.nodebuffer),i)for(;1<e;)try{return s.stringifyByChunk(t,r,e)}catch(t){e=Math.floor(e/2)}return s.stringifyByChar(t)}function d(t,e){for(var r=0;r<t.length;r++)e[r]=t[r];return e}a.applyFromCharCode=f;var c={};c.string={string:n,array:function(t){return l(t,new Array(t.length))},arraybuffer:function(t){return c.string.uint8array(t).buffer},uint8array:function(t){return l(t,new Uint8Array(t.length))},nodebuffer:function(t){return l(t,r.allocBuffer(t.length))}},c.array={string:f,array:n,arraybuffer:function(t){return new Uint8Array(t).buffer},uint8array:function(t){return new Uint8Array(t)},nodebuffer:function(t){return r.newBufferFrom(t)}},c.arraybuffer={string:function(t){return f(new Uint8Array(t))},array:function(t){return d(new Uint8Array(t),new Array(t.byteLength))},arraybuffer:n,uint8array:function(t){return new Uint8Array(t)},nodebuffer:function(t){return r.newBufferFrom(new Uint8Array(t))}},c.uint8array={string:f,array:function(t){return d(t,new Array(t.length))},arraybuffer:function(t){return t.buffer},uint8array:n,nodebuffer:function(t){return r.newBufferFrom(t)}},c.nodebuffer={string:f,array:function(t){return d(t,new Array(t.length))},arraybuffer:function(t){return c.nodebuffer.uint8array(t).buffer},uint8array:function(t){return d(t,new Uint8Array(t.length))},nodebuffer:n},a.transformTo=function(t,e){if(e=e||"",!t)return e;a.checkSupport(t);var r=a.getTypeOf(e);return c[r][t](e)},a.resolve=function(t){for(var e=t.split("/"),r=[],i=0;i<e.length;i++){var n=e[i];"."===n||""===n&&0!==i&&i!==e.length-1||(".."===n?r.pop():r.push(n))}return r.join("/")},a.getTypeOf=function(t){return"string"==typeof t?"string":"[object Array]"===Object.prototype.toString.call(t)?"array":o.nodebuffer&&r.isBuffer(t)?"nodebuffer":o.uint8array&&t instanceof Uint8Array?"uint8array":o.arraybuffer&&t instanceof ArrayBuffer?"arraybuffer":void 0},a.checkSupport=function(t){if(!o[t.toLowerCase()])throw new Error(t+" is not supported by this platform")},a.MAX_VALUE_16BITS=65535,a.MAX_VALUE_32BITS=-1,a.pretty=function(t){var e,r,i="";for(r=0;r<(t||"").length;r++)i+="\\x"+((e=t.charCodeAt(r))<16?"0":"")+e.toString(16).toUpperCase();return i},a.delay=function(t,e,r){i(function(){t.apply(r||null,e||[])})},a.inherits=function(t,e){function r(){}r.prototype=e.prototype,t.prototype=new r},a.extend=function(){var t,e,r={};for(t=0;t<arguments.length;t++)for(e in arguments[t])arguments[t].hasOwnProperty(e)&&void 0===r[e]&&(r[e]=arguments[t][e]);return r},a.prepareContent=function(r,t,i,n,s){return u.Promise.resolve(t).then(function(i){return o.blob&&(i instanceof Blob||-1!==["[object File]","[object Blob]"].indexOf(Object.prototype.toString.call(i)))&&"undefined"!=typeof FileReader?new u.Promise(function(e,r){var t=new FileReader;t.onload=function(t){e(t.target.result)},t.onerror=function(t){r(t.target.error)},t.readAsArrayBuffer(i)}):i}).then(function(t){var e=a.getTypeOf(t);return e?("arraybuffer"===e?t=a.transformTo("uint8array",t):"string"===e&&(s?t=h.decode(t):i&&!0!==n&&(t=function(t){return l(t,o.uint8array?new Uint8Array(t.length):new Array(t.length))}(t))),t):u.Promise.reject(new Error("Can't read the data of '"+r+"'. Is it in a supported JavaScript type (String, Blob, ArrayBuffer, etc) ?"))})}},{"./base64":1,"./external":6,"./nodejsUtils":14,"./support":30,"set-immediate-shim":54}],33:[function(t,e,r){"use strict";var i=t("./reader/readerFor"),n=t("./utils"),s=t("./signature"),a=t("./zipEntry"),o=(t("./utf8"),t("./support"));function h(t){this.files=[],this.loadOptions=t}h.prototype={checkSignature:function(t){if(!this.reader.readAndCheckSignature(t)){this.reader.index-=4;var e=this.reader.readString(4);throw new Error("Corrupted zip or bug: unexpected signature ("+n.pretty(e)+", expected "+n.pretty(t)+")")}},isSignature:function(t,e){var r=this.reader.index;this.reader.setIndex(t);var i=this.reader.readString(4)===e;return this.reader.setIndex(r),i},readBlockEndOfCentral:function(){this.diskNumber=this.reader.readInt(2),this.diskWithCentralDirStart=this.reader.readInt(2),this.centralDirRecordsOnThisDisk=this.reader.readInt(2),this.centralDirRecords=this.reader.readInt(2),this.centralDirSize=this.reader.readInt(4),this.centralDirOffset=this.reader.readInt(4),this.zipCommentLength=this.reader.readInt(2);var t=this.reader.readData(this.zipCommentLength),e=o.uint8array?"uint8array":"array",r=n.transformTo(e,t);this.zipComment=this.loadOptions.decodeFileName(r)},readBlockZip64EndOfCentral:function(){this.zip64EndOfCentralSize=this.reader.readInt(8),this.reader.skip(4),this.diskNumber=this.reader.readInt(4),this.diskWithCentralDirStart=this.reader.readInt(4),this.centralDirRecordsOnThisDisk=this.reader.readInt(8),this.centralDirRecords=this.reader.readInt(8),this.centralDirSize=this.reader.readInt(8),this.centralDirOffset=this.reader.readInt(8),this.zip64ExtensibleData={};for(var t,e,r,i=this.zip64EndOfCentralSize-44;0<i;)t=this.reader.readInt(2),e=this.reader.readInt(4),r=this.reader.readData(e),this.zip64ExtensibleData[t]={id:t,length:e,value:r}},readBlockZip64EndOfCentralLocator:function(){if(this.diskWithZip64CentralDirStart=this.reader.readInt(4),this.relativeOffsetEndOfZip64CentralDir=this.reader.readInt(8),this.disksCount=this.reader.readInt(4),1<this.disksCount)throw new Error("Multi-volumes zip are not supported")},readLocalFiles:function(){var t,e;for(t=0;t<this.files.length;t++)e=this.files[t],this.reader.setIndex(e.localHeaderOffset),this.checkSignature(s.LOCAL_FILE_HEADER),e.readLocalPart(this.reader),e.handleUTF8(),e.processAttributes()},readCentralDir:function(){var t;for(this.reader.setIndex(this.centralDirOffset);this.reader.readAndCheckSignature(s.CENTRAL_FILE_HEADER);)(t=new a({zip64:this.zip64},this.loadOptions)).readCentralPart(this.reader),this.files.push(t);if(this.centralDirRecords!==this.files.length&&0!==this.centralDirRecords&&0===this.files.length)throw new Error("Corrupted zip or bug: expected "+this.centralDirRecords+" records in central dir, got "+this.files.length)},readEndOfCentral:function(){var t=this.reader.lastIndexOfSignature(s.CENTRAL_DIRECTORY_END);if(t<0)throw!this.isSignature(0,s.LOCAL_FILE_HEADER)?new Error("Can't find end of central directory : is this a zip file ? If it is, see https://stuk.github.io/jszip/documentation/howto/read_zip.html"):new Error("Corrupted zip: can't find end of central directory");this.reader.setIndex(t);var e=t;if(this.checkSignature(s.CENTRAL_DIRECTORY_END),this.readBlockEndOfCentral(),this.diskNumber===n.MAX_VALUE_16BITS||this.diskWithCentralDirStart===n.MAX_VALUE_16BITS||this.centralDirRecordsOnThisDisk===n.MAX_VALUE_16BITS||this.centralDirRecords===n.MAX_VALUE_16BITS||this.centralDirSize===n.MAX_VALUE_32BITS||this.centralDirOffset===n.MAX_VALUE_32BITS){if(this.zip64=!0,(t=this.reader.lastIndexOfSignature(s.ZIP64_CENTRAL_DIRECTORY_LOCATOR))<0)throw new Error("Corrupted zip: can't find the ZIP64 end of central directory locator");if(this.reader.setIndex(t),this.checkSignature(s.ZIP64_CENTRAL_DIRECTORY_LOCATOR),this.readBlockZip64EndOfCentralLocator(),!this.isSignature(this.relativeOffsetEndOfZip64CentralDir,s.ZIP64_CENTRAL_DIRECTORY_END)&&(this.relativeOffsetEndOfZip64CentralDir=this.reader.lastIndexOfSignature(s.ZIP64_CENTRAL_DIRECTORY_END),this.relativeOffsetEndOfZip64CentralDir<0))throw new Error("Corrupted zip: can't find the ZIP64 end of central directory");this.reader.setIndex(this.relativeOffsetEndOfZip64CentralDir),this.checkSignature(s.ZIP64_CENTRAL_DIRECTORY_END),this.readBlockZip64EndOfCentral()}var r=this.centralDirOffset+this.centralDirSize;this.zip64&&(r+=20,r+=12+this.zip64EndOfCentralSize);var i=e-r;if(0<i)this.isSignature(e,s.CENTRAL_FILE_HEADER)||(this.reader.zero=i);else if(i<0)throw new Error("Corrupted zip: missing "+Math.abs(i)+" bytes.")},prepareReader:function(t){this.reader=i(t)},load:function(t){this.prepareReader(t),this.readEndOfCentral(),this.readCentralDir(),this.readLocalFiles()}},e.exports=h},{"./reader/readerFor":22,"./signature":23,"./support":30,"./utf8":31,"./utils":32,"./zipEntry":34}],34:[function(t,e,r){"use strict";var i=t("./reader/readerFor"),s=t("./utils"),n=t("./compressedObject"),a=t("./crc32"),o=t("./utf8"),h=t("./compressions"),u=t("./support");function l(t,e){this.options=t,this.loadOptions=e}l.prototype={isEncrypted:function(){return 1==(1&this.bitFlag)},useUTF8:function(){return 2048==(2048&this.bitFlag)},readLocalPart:function(t){var e,r;if(t.skip(22),this.fileNameLength=t.readInt(2),r=t.readInt(2),this.fileName=t.readData(this.fileNameLength),t.skip(r),-1===this.compressedSize||-1===this.uncompressedSize)throw new Error("Bug or corrupted zip : didn't get enough information from the central directory (compressedSize === -1 || uncompressedSize === -1)");if(null===(e=function(t){for(var e in h)if(h.hasOwnProperty(e)&&h[e].magic===t)return h[e];return null}(this.compressionMethod)))throw new Error("Corrupted zip : compression "+s.pretty(this.compressionMethod)+" unknown (inner file : "+s.transformTo("string",this.fileName)+")");this.decompressed=new n(this.compressedSize,this.uncompressedSize,this.crc32,e,t.readData(this.compressedSize))},readCentralPart:function(t){this.versionMadeBy=t.readInt(2),t.skip(2),this.bitFlag=t.readInt(2),this.compressionMethod=t.readString(2),this.date=t.readDate(),this.crc32=t.readInt(4),this.compressedSize=t.readInt(4),this.uncompressedSize=t.readInt(4);var e=t.readInt(2);if(this.extraFieldsLength=t.readInt(2),this.fileCommentLength=t.readInt(2),this.diskNumberStart=t.readInt(2),this.internalFileAttributes=t.readInt(2),this.externalFileAttributes=t.readInt(4),this.localHeaderOffset=t.readInt(4),this.isEncrypted())throw new Error("Encrypted zip are not supported");t.skip(e),this.readExtraFields(t),this.parseZIP64ExtraField(t),this.fileComment=t.readData(this.fileCommentLength)},processAttributes:function(){this.unixPermissions=null,this.dosPermissions=null;var t=this.versionMadeBy>>8;this.dir=!!(16&this.externalFileAttributes),0==t&&(this.dosPermissions=63&this.externalFileAttributes),3==t&&(this.unixPermissions=this.externalFileAttributes>>16&65535),this.dir||"/"!==this.fileNameStr.slice(-1)||(this.dir=!0)},parseZIP64ExtraField:function(t){if(this.extraFields[1]){var e=i(this.extraFields[1].value);this.uncompressedSize===s.MAX_VALUE_32BITS&&(this.uncompressedSize=e.readInt(8)),this.compressedSize===s.MAX_VALUE_32BITS&&(this.compressedSize=e.readInt(8)),this.localHeaderOffset===s.MAX_VALUE_32BITS&&(this.localHeaderOffset=e.readInt(8)),this.diskNumberStart===s.MAX_VALUE_32BITS&&(this.diskNumberStart=e.readInt(4))}},readExtraFields:function(t){var e,r,i,n=t.index+this.extraFieldsLength;for(this.extraFields||(this.extraFields={});t.index+4<n;)e=t.readInt(2),r=t.readInt(2),i=t.readData(r),this.extraFields[e]={id:e,length:r,value:i};t.setIndex(n)},handleUTF8:function(){var t=u.uint8array?"uint8array":"array";if(this.useUTF8())this.fileNameStr=o.utf8decode(this.fileName),this.fileCommentStr=o.utf8decode(this.fileComment);else{var e=this.findExtraFieldUnicodePath();if(null!==e)this.fileNameStr=e;else{var r=s.transformTo(t,this.fileName);this.fileNameStr=this.loadOptions.decodeFileName(r)}var i=this.findExtraFieldUnicodeComment();if(null!==i)this.fileCommentStr=i;else{var n=s.transformTo(t,this.fileComment);this.fileCommentStr=this.loadOptions.decodeFileName(n)}}},findExtraFieldUnicodePath:function(){var t=this.extraFields[28789];if(t){var e=i(t.value);return 1!==e.readInt(1)?null:a(this.fileName)!==e.readInt(4)?null:o.utf8decode(e.readData(t.length-5))}return null},findExtraFieldUnicodeComment:function(){var t=this.extraFields[25461];if(t){var e=i(t.value);return 1!==e.readInt(1)?null:a(this.fileComment)!==e.readInt(4)?null:o.utf8decode(e.readData(t.length-5))}return null}},e.exports=l},{"./compressedObject":2,"./compressions":3,"./crc32":4,"./reader/readerFor":22,"./support":30,"./utf8":31,"./utils":32}],35:[function(t,e,r){"use strict";function i(t,e,r){this.name=t,this.dir=r.dir,this.date=r.date,this.comment=r.comment,this.unixPermissions=r.unixPermissions,this.dosPermissions=r.dosPermissions,this._data=e,this._dataBinary=r.binary,this.options={compression:r.compression,compressionOptions:r.compressionOptions}}var s=t("./stream/StreamHelper"),n=t("./stream/DataWorker"),a=t("./utf8"),o=t("./compressedObject"),h=t("./stream/GenericWorker");i.prototype={internalStream:function(t){var e=null,r="string";try{if(!t)throw new Error("No output type specified.");var i="string"===(r=t.toLowerCase())||"text"===r;"binarystring"!==r&&"text"!==r||(r="string"),e=this._decompressWorker();var n=!this._dataBinary;n&&!i&&(e=e.pipe(new a.Utf8EncodeWorker)),!n&&i&&(e=e.pipe(new a.Utf8DecodeWorker))}catch(t){(e=new h("error")).error(t)}return new s(e,r,"")},async:function(t,e){return this.internalStream(t).accumulate(e)},nodeStream:function(t,e){return this.internalStream(t||"nodebuffer").toNodejsStream(e)},_compressWorker:function(t,e){if(this._data instanceof o&&this._data.compression.magic===t.magic)return this._data.getCompressedWorker();var r=this._decompressWorker();return this._dataBinary||(r=r.pipe(new a.Utf8EncodeWorker)),o.createWorkerFrom(r,t,e)},_decompressWorker:function(){return this._data instanceof o?this._data.getContentWorker():this._data instanceof h?this._data:new n(this._data)}};for(var u=["asText","asBinary","asNodeBuffer","asUint8Array","asArrayBuffer"],l=function(){throw new Error("This method has been removed in JSZip 3.0, please check the upgrade guide.")},f=0;f<u.length;f++)i.prototype[u[f]]=l;e.exports=i},{"./compressedObject":2,"./stream/DataWorker":27,"./stream/GenericWorker":28,"./stream/StreamHelper":29,"./utf8":31}],36:[function(t,l,e){(function(e){"use strict";var r,i,t=e.MutationObserver||e.WebKitMutationObserver;if(t){var n=0,s=new t(u),a=e.document.createTextNode("");s.observe(a,{characterData:!0}),r=function(){a.data=n=++n%2}}else if(e.setImmediate||void 0===e.MessageChannel)r="document"in e&&"onreadystatechange"in e.document.createElement("script")?function(){var t=e.document.createElement("script");t.onreadystatechange=function(){u(),t.onreadystatechange=null,t.parentNode.removeChild(t),t=null},e.document.documentElement.appendChild(t)}:function(){setTimeout(u,0)};else{var o=new e.MessageChannel;o.port1.onmessage=u,r=function(){o.port2.postMessage(0)}}var h=[];function u(){var t,e;i=!0;for(var r=h.length;r;){for(e=h,h=[],t=-1;++t<r;)e[t]();r=h.length}i=!1}l.exports=function(t){1!==h.push(t)||i||r()}}).call(this,"undefined"!=typeof __webpack_require__.g?__webpack_require__.g:"undefined"!=typeof self?self:"undefined"!=typeof window?window:{})},{}],37:[function(t,e,r){"use strict";var n=t("immediate");function u(){}var l={},s=["REJECTED"],a=["FULFILLED"],i=["PENDING"];function o(t){if("function"!=typeof t)throw new TypeError("resolver must be a function");this.state=i,this.queue=[],this.outcome=void 0,t!==u&&c(this,t)}function h(t,e,r){this.promise=t,"function"==typeof e&&(this.onFulfilled=e,this.callFulfilled=this.otherCallFulfilled),"function"==typeof r&&(this.onRejected=r,this.callRejected=this.otherCallRejected)}function f(e,r,i){n(function(){var t;try{t=r(i)}catch(t){return l.reject(e,t)}t===e?l.reject(e,new TypeError("Cannot resolve promise with itself")):l.resolve(e,t)})}function d(t){var e=t&&t.then;if(t&&("object"==typeof t||"function"==typeof t)&&"function"==typeof e)return function(){e.apply(t,arguments)}}function c(e,t){var r=!1;function i(t){r||(r=!0,l.reject(e,t))}function n(t){r||(r=!0,l.resolve(e,t))}var s=p(function(){t(n,i)});"error"===s.status&&i(s.value)}function p(t,e){var r={};try{r.value=t(e),r.status="success"}catch(t){r.status="error",r.value=t}return r}(e.exports=o).prototype.finally=function(e){if("function"!=typeof e)return this;var r=this.constructor;return this.then(function(t){return r.resolve(e()).then(function(){return t})},function(t){return r.resolve(e()).then(function(){throw t})})},o.prototype.catch=function(t){return this.then(null,t)},o.prototype.then=function(t,e){if("function"!=typeof t&&this.state===a||"function"!=typeof e&&this.state===s)return this;var r=new this.constructor(u);this.state!==i?f(r,this.state===a?t:e,this.outcome):this.queue.push(new h(r,t,e));return r},h.prototype.callFulfilled=function(t){l.resolve(this.promise,t)},h.prototype.otherCallFulfilled=function(t){f(this.promise,this.onFulfilled,t)},h.prototype.callRejected=function(t){l.reject(this.promise,t)},h.prototype.otherCallRejected=function(t){f(this.promise,this.onRejected,t)},l.resolve=function(t,e){var r=p(d,e);if("error"===r.status)return l.reject(t,r.value);var i=r.value;if(i)c(t,i);else{t.state=a,t.outcome=e;for(var n=-1,s=t.queue.length;++n<s;)t.queue[n].callFulfilled(e)}return t},l.reject=function(t,e){t.state=s,t.outcome=e;for(var r=-1,i=t.queue.length;++r<i;)t.queue[r].callRejected(e);return t},o.resolve=function(t){if(t instanceof this)return t;return l.resolve(new this(u),t)},o.reject=function(t){var e=new this(u);return l.reject(e,t)},o.all=function(t){var r=this;if("[object Array]"!==Object.prototype.toString.call(t))return this.reject(new TypeError("must be an array"));var i=t.length,n=!1;if(!i)return this.resolve([]);var s=new Array(i),a=0,e=-1,o=new this(u);for(;++e<i;)h(t[e],e);return o;function h(t,e){r.resolve(t).then(function(t){s[e]=t,++a!==i||n||(n=!0,l.resolve(o,s))},function(t){n||(n=!0,l.reject(o,t))})}},o.race=function(t){var e=this;if("[object Array]"!==Object.prototype.toString.call(t))return this.reject(new TypeError("must be an array"));var r=t.length,i=!1;if(!r)return this.resolve([]);var n=-1,s=new this(u);for(;++n<r;)a=t[n],e.resolve(a).then(function(t){i||(i=!0,l.resolve(s,t))},function(t){i||(i=!0,l.reject(s,t))});var a;return s}},{immediate:36}],38:[function(t,e,r){"use strict";var i={};(0,t("./lib/utils/common").assign)(i,t("./lib/deflate"),t("./lib/inflate"),t("./lib/zlib/constants")),e.exports=i},{"./lib/deflate":39,"./lib/inflate":40,"./lib/utils/common":41,"./lib/zlib/constants":44}],39:[function(t,e,r){"use strict";var a=t("./zlib/deflate"),o=t("./utils/common"),h=t("./utils/strings"),n=t("./zlib/messages"),s=t("./zlib/zstream"),u=Object.prototype.toString,l=0,f=-1,d=0,c=8;function p(t){if(!(this instanceof p))return new p(t);this.options=o.assign({level:f,method:c,chunkSize:16384,windowBits:15,memLevel:8,strategy:d,to:""},t||{});var e=this.options;e.raw&&0<e.windowBits?e.windowBits=-e.windowBits:e.gzip&&0<e.windowBits&&e.windowBits<16&&(e.windowBits+=16),this.err=0,this.msg="",this.ended=!1,this.chunks=[],this.strm=new s,this.strm.avail_out=0;var r=a.deflateInit2(this.strm,e.level,e.method,e.windowBits,e.memLevel,e.strategy);if(r!==l)throw new Error(n[r]);if(e.header&&a.deflateSetHeader(this.strm,e.header),e.dictionary){var i;if(i="string"==typeof e.dictionary?h.string2buf(e.dictionary):"[object ArrayBuffer]"===u.call(e.dictionary)?new Uint8Array(e.dictionary):e.dictionary,(r=a.deflateSetDictionary(this.strm,i))!==l)throw new Error(n[r]);this._dict_set=!0}}function i(t,e){var r=new p(e);if(r.push(t,!0),r.err)throw r.msg||n[r.err];return r.result}p.prototype.push=function(t,e){var r,i,n=this.strm,s=this.options.chunkSize;if(this.ended)return!1;i=e===~~e?e:!0===e?4:0,"string"==typeof t?n.input=h.string2buf(t):"[object ArrayBuffer]"===u.call(t)?n.input=new Uint8Array(t):n.input=t,n.next_in=0,n.avail_in=n.input.length;do{if(0===n.avail_out&&(n.output=new o.Buf8(s),n.next_out=0,n.avail_out=s),1!==(r=a.deflate(n,i))&&r!==l)return this.onEnd(r),!(this.ended=!0);0!==n.avail_out&&(0!==n.avail_in||4!==i&&2!==i)||("string"===this.options.to?this.onData(h.buf2binstring(o.shrinkBuf(n.output,n.next_out))):this.onData(o.shrinkBuf(n.output,n.next_out)))}while((0<n.avail_in||0===n.avail_out)&&1!==r);return 4===i?(r=a.deflateEnd(this.strm),this.onEnd(r),this.ended=!0,r===l):2!==i||(this.onEnd(l),!(n.avail_out=0))},p.prototype.onData=function(t){this.chunks.push(t)},p.prototype.onEnd=function(t){t===l&&("string"===this.options.to?this.result=this.chunks.join(""):this.result=o.flattenChunks(this.chunks)),this.chunks=[],this.err=t,this.msg=this.strm.msg},r.Deflate=p,r.deflate=i,r.deflateRaw=function(t,e){return(e=e||{}).raw=!0,i(t,e)},r.gzip=function(t,e){return(e=e||{}).gzip=!0,i(t,e)}},{"./utils/common":41,"./utils/strings":42,"./zlib/deflate":46,"./zlib/messages":51,"./zlib/zstream":53}],40:[function(t,e,r){"use strict";var d=t("./zlib/inflate"),c=t("./utils/common"),p=t("./utils/strings"),m=t("./zlib/constants"),i=t("./zlib/messages"),n=t("./zlib/zstream"),s=t("./zlib/gzheader"),_=Object.prototype.toString;function a(t){if(!(this instanceof a))return new a(t);this.options=c.assign({chunkSize:16384,windowBits:0,to:""},t||{});var e=this.options;e.raw&&0<=e.windowBits&&e.windowBits<16&&(e.windowBits=-e.windowBits,0===e.windowBits&&(e.windowBits=-15)),!(0<=e.windowBits&&e.windowBits<16)||t&&t.windowBits||(e.windowBits+=32),15<e.windowBits&&e.windowBits<48&&0==(15&e.windowBits)&&(e.windowBits|=15),this.err=0,this.msg="",this.ended=!1,this.chunks=[],this.strm=new n,this.strm.avail_out=0;var r=d.inflateInit2(this.strm,e.windowBits);if(r!==m.Z_OK)throw new Error(i[r]);this.header=new s,d.inflateGetHeader(this.strm,this.header)}function o(t,e){var r=new a(e);if(r.push(t,!0),r.err)throw r.msg||i[r.err];return r.result}a.prototype.push=function(t,e){var r,i,n,s,a,o,h=this.strm,u=this.options.chunkSize,l=this.options.dictionary,f=!1;if(this.ended)return!1;i=e===~~e?e:!0===e?m.Z_FINISH:m.Z_NO_FLUSH,"string"==typeof t?h.input=p.binstring2buf(t):"[object ArrayBuffer]"===_.call(t)?h.input=new Uint8Array(t):h.input=t,h.next_in=0,h.avail_in=h.input.length;do{if(0===h.avail_out&&(h.output=new c.Buf8(u),h.next_out=0,h.avail_out=u),(r=d.inflate(h,m.Z_NO_FLUSH))===m.Z_NEED_DICT&&l&&(o="string"==typeof l?p.string2buf(l):"[object ArrayBuffer]"===_.call(l)?new Uint8Array(l):l,r=d.inflateSetDictionary(this.strm,o)),r===m.Z_BUF_ERROR&&!0===f&&(r=m.Z_OK,f=!1),r!==m.Z_STREAM_END&&r!==m.Z_OK)return this.onEnd(r),!(this.ended=!0);h.next_out&&(0!==h.avail_out&&r!==m.Z_STREAM_END&&(0!==h.avail_in||i!==m.Z_FINISH&&i!==m.Z_SYNC_FLUSH)||("string"===this.options.to?(n=p.utf8border(h.output,h.next_out),s=h.next_out-n,a=p.buf2string(h.output,n),h.next_out=s,h.avail_out=u-s,s&&c.arraySet(h.output,h.output,n,s,0),this.onData(a)):this.onData(c.shrinkBuf(h.output,h.next_out)))),0===h.avail_in&&0===h.avail_out&&(f=!0)}while((0<h.avail_in||0===h.avail_out)&&r!==m.Z_STREAM_END);return r===m.Z_STREAM_END&&(i=m.Z_FINISH),i===m.Z_FINISH?(r=d.inflateEnd(this.strm),this.onEnd(r),this.ended=!0,r===m.Z_OK):i!==m.Z_SYNC_FLUSH||(this.onEnd(m.Z_OK),!(h.avail_out=0))},a.prototype.onData=function(t){this.chunks.push(t)},a.prototype.onEnd=function(t){t===m.Z_OK&&("string"===this.options.to?this.result=this.chunks.join(""):this.result=c.flattenChunks(this.chunks)),this.chunks=[],this.err=t,this.msg=this.strm.msg},r.Inflate=a,r.inflate=o,r.inflateRaw=function(t,e){return(e=e||{}).raw=!0,o(t,e)},r.ungzip=o},{"./utils/common":41,"./utils/strings":42,"./zlib/constants":44,"./zlib/gzheader":47,"./zlib/inflate":49,"./zlib/messages":51,"./zlib/zstream":53}],41:[function(t,e,r){"use strict";var i="undefined"!=typeof Uint8Array&&"undefined"!=typeof Uint16Array&&"undefined"!=typeof Int32Array;r.assign=function(t){for(var e=Array.prototype.slice.call(arguments,1);e.length;){var r=e.shift();if(r){if("object"!=typeof r)throw new TypeError(r+"must be non-object");for(var i in r)r.hasOwnProperty(i)&&(t[i]=r[i])}}return t},r.shrinkBuf=function(t,e){return t.length===e?t:t.subarray?t.subarray(0,e):(t.length=e,t)};var n={arraySet:function(t,e,r,i,n){if(e.subarray&&t.subarray)t.set(e.subarray(r,r+i),n);else for(var s=0;s<i;s++)t[n+s]=e[r+s]},flattenChunks:function(t){var e,r,i,n,s,a;for(e=i=0,r=t.length;e<r;e++)i+=t[e].length;for(a=new Uint8Array(i),e=n=0,r=t.length;e<r;e++)s=t[e],a.set(s,n),n+=s.length;return a}},s={arraySet:function(t,e,r,i,n){for(var s=0;s<i;s++)t[n+s]=e[r+s]},flattenChunks:function(t){return[].concat.apply([],t)}};r.setTyped=function(t){t?(r.Buf8=Uint8Array,r.Buf16=Uint16Array,r.Buf32=Int32Array,r.assign(r,n)):(r.Buf8=Array,r.Buf16=Array,r.Buf32=Array,r.assign(r,s))},r.setTyped(i)},{}],42:[function(t,e,r){"use strict";var h=t("./common"),n=!0,s=!0;try{String.fromCharCode.apply(null,[0])}catch(t){n=!1}try{String.fromCharCode.apply(null,new Uint8Array(1))}catch(t){s=!1}for(var u=new h.Buf8(256),i=0;i<256;i++)u[i]=252<=i?6:248<=i?5:240<=i?4:224<=i?3:192<=i?2:1;function l(t,e){if(e<65537&&(t.subarray&&s||!t.subarray&&n))return String.fromCharCode.apply(null,h.shrinkBuf(t,e));for(var r="",i=0;i<e;i++)r+=String.fromCharCode(t[i]);return r}u[254]=u[254]=1,r.string2buf=function(t){var e,r,i,n,s,a=t.length,o=0;for(n=0;n<a;n++)55296==(64512&(r=t.charCodeAt(n)))&&n+1<a&&56320==(64512&(i=t.charCodeAt(n+1)))&&(r=65536+(r-55296<<10)+(i-56320),n++),o+=r<128?1:r<2048?2:r<65536?3:4;for(e=new h.Buf8(o),n=s=0;s<o;n++)55296==(64512&(r=t.charCodeAt(n)))&&n+1<a&&56320==(64512&(i=t.charCodeAt(n+1)))&&(r=65536+(r-55296<<10)+(i-56320),n++),r<128?e[s++]=r:(r<2048?e[s++]=192|r>>>6:(r<65536?e[s++]=224|r>>>12:(e[s++]=240|r>>>18,e[s++]=128|r>>>12&63),e[s++]=128|r>>>6&63),e[s++]=128|63&r);return e},r.buf2binstring=function(t){return l(t,t.length)},r.binstring2buf=function(t){for(var e=new h.Buf8(t.length),r=0,i=e.length;r<i;r++)e[r]=t.charCodeAt(r);return e},r.buf2string=function(t,e){var r,i,n,s,a=e||t.length,o=new Array(2*a);for(r=i=0;r<a;)if((n=t[r++])<128)o[i++]=n;else if(4<(s=u[n]))o[i++]=65533,r+=s-1;else{for(n&=2===s?31:3===s?15:7;1<s&&r<a;)n=n<<6|63&t[r++],s--;1<s?o[i++]=65533:n<65536?o[i++]=n:(n-=65536,o[i++]=55296|n>>10&1023,o[i++]=56320|1023&n)}return l(o,i)},r.utf8border=function(t,e){var r;for((e=e||t.length)>t.length&&(e=t.length),r=e-1;0<=r&&128==(192&t[r]);)r--;return r<0?e:0===r?e:r+u[t[r]]>e?r:e}},{"./common":41}],43:[function(t,e,r){"use strict";e.exports=function(t,e,r,i){for(var n=65535&t|0,s=t>>>16&65535|0,a=0;0!==r;){for(r-=a=2e3<r?2e3:r;s=s+(n=n+e[i++]|0)|0,--a;);n%=65521,s%=65521}return n|s<<16|0}},{}],44:[function(t,e,r){"use strict";e.exports={Z_NO_FLUSH:0,Z_PARTIAL_FLUSH:1,Z_SYNC_FLUSH:2,Z_FULL_FLUSH:3,Z_FINISH:4,Z_BLOCK:5,Z_TREES:6,Z_OK:0,Z_STREAM_END:1,Z_NEED_DICT:2,Z_ERRNO:-1,Z_STREAM_ERROR:-2,Z_DATA_ERROR:-3,Z_BUF_ERROR:-5,Z_NO_COMPRESSION:0,Z_BEST_SPEED:1,Z_BEST_COMPRESSION:9,Z_DEFAULT_COMPRESSION:-1,Z_FILTERED:1,Z_HUFFMAN_ONLY:2,Z_RLE:3,Z_FIXED:4,Z_DEFAULT_STRATEGY:0,Z_BINARY:0,Z_TEXT:1,Z_UNKNOWN:2,Z_DEFLATED:8}},{}],45:[function(t,e,r){"use strict";var o=function(){for(var t,e=[],r=0;r<256;r++){t=r;for(var i=0;i<8;i++)t=1&t?3988292384^t>>>1:t>>>1;e[r]=t}return e}();e.exports=function(t,e,r,i){var n=o,s=i+r;t^=-1;for(var a=i;a<s;a++)t=t>>>8^n[255&(t^e[a])];return-1^t}},{}],46:[function(t,e,r){"use strict";var h,d=t("../utils/common"),u=t("./trees"),c=t("./adler32"),p=t("./crc32"),i=t("./messages"),l=0,f=4,m=0,_=-2,g=-1,b=4,n=2,v=8,y=9,s=286,a=30,o=19,w=2*s+1,k=15,x=3,S=258,z=S+x+1,C=42,E=113,A=1,I=2,O=3,B=4;function R(t,e){return t.msg=i[e],e}function T(t){return(t<<1)-(4<t?9:0)}function D(t){for(var e=t.length;0<=--e;)t[e]=0}function F(t){var e=t.state,r=e.pending;r>t.avail_out&&(r=t.avail_out),0!==r&&(d.arraySet(t.output,e.pending_buf,e.pending_out,r,t.next_out),t.next_out+=r,e.pending_out+=r,t.total_out+=r,t.avail_out-=r,e.pending-=r,0===e.pending&&(e.pending_out=0))}function N(t,e){u._tr_flush_block(t,0<=t.block_start?t.block_start:-1,t.strstart-t.block_start,e),t.block_start=t.strstart,F(t.strm)}function U(t,e){t.pending_buf[t.pending++]=e}function P(t,e){t.pending_buf[t.pending++]=e>>>8&255,t.pending_buf[t.pending++]=255&e}function L(t,e){var r,i,n=t.max_chain_length,s=t.strstart,a=t.prev_length,o=t.nice_match,h=t.strstart>t.w_size-z?t.strstart-(t.w_size-z):0,u=t.window,l=t.w_mask,f=t.prev,d=t.strstart+S,c=u[s+a-1],p=u[s+a];t.prev_length>=t.good_match&&(n>>=2),o>t.lookahead&&(o=t.lookahead);do{if(u[(r=e)+a]===p&&u[r+a-1]===c&&u[r]===u[s]&&u[++r]===u[s+1]){s+=2,r++;do{}while(u[++s]===u[++r]&&u[++s]===u[++r]&&u[++s]===u[++r]&&u[++s]===u[++r]&&u[++s]===u[++r]&&u[++s]===u[++r]&&u[++s]===u[++r]&&u[++s]===u[++r]&&s<d);if(i=S-(d-s),s=d-S,a<i){if(t.match_start=e,o<=(a=i))break;c=u[s+a-1],p=u[s+a]}}}while((e=f[e&l])>h&&0!=--n);return a<=t.lookahead?a:t.lookahead}function j(t){var e,r,i,n,s,a,o,h,u,l,f=t.w_size;do{if(n=t.window_size-t.lookahead-t.strstart,t.strstart>=f+(f-z)){for(d.arraySet(t.window,t.window,f,f,0),t.match_start-=f,t.strstart-=f,t.block_start-=f,e=r=t.hash_size;i=t.head[--e],t.head[e]=f<=i?i-f:0,--r;);for(e=r=f;i=t.prev[--e],t.prev[e]=f<=i?i-f:0,--r;);n+=f}if(0===t.strm.avail_in)break;if(a=t.strm,o=t.window,h=t.strstart+t.lookahead,u=n,l=void 0,l=a.avail_in,u<l&&(l=u),r=0===l?0:(a.avail_in-=l,d.arraySet(o,a.input,a.next_in,l,h),1===a.state.wrap?a.adler=c(a.adler,o,l,h):2===a.state.wrap&&(a.adler=p(a.adler,o,l,h)),a.next_in+=l,a.total_in+=l,l),t.lookahead+=r,t.lookahead+t.insert>=x)for(s=t.strstart-t.insert,t.ins_h=t.window[s],t.ins_h=(t.ins_h<<t.hash_shift^t.window[s+1])&t.hash_mask;t.insert&&(t.ins_h=(t.ins_h<<t.hash_shift^t.window[s+x-1])&t.hash_mask,t.prev[s&t.w_mask]=t.head[t.ins_h],t.head[t.ins_h]=s,s++,t.insert--,!(t.lookahead+t.insert<x)););}while(t.lookahead<z&&0!==t.strm.avail_in)}function Z(t,e){for(var r,i;;){if(t.lookahead<z){if(j(t),t.lookahead<z&&e===l)return A;if(0===t.lookahead)break}if(r=0,t.lookahead>=x&&(t.ins_h=(t.ins_h<<t.hash_shift^t.window[t.strstart+x-1])&t.hash_mask,r=t.prev[t.strstart&t.w_mask]=t.head[t.ins_h],t.head[t.ins_h]=t.strstart),0!==r&&t.strstart-r<=t.w_size-z&&(t.match_length=L(t,r)),t.match_length>=x)if(i=u._tr_tally(t,t.strstart-t.match_start,t.match_length-x),t.lookahead-=t.match_length,t.match_length<=t.max_lazy_match&&t.lookahead>=x){for(t.match_length--;t.strstart++,t.ins_h=(t.ins_h<<t.hash_shift^t.window[t.strstart+x-1])&t.hash_mask,r=t.prev[t.strstart&t.w_mask]=t.head[t.ins_h],t.head[t.ins_h]=t.strstart,0!=--t.match_length;);t.strstart++}else t.strstart+=t.match_length,t.match_length=0,t.ins_h=t.window[t.strstart],t.ins_h=(t.ins_h<<t.hash_shift^t.window[t.strstart+1])&t.hash_mask;else i=u._tr_tally(t,0,t.window[t.strstart]),t.lookahead--,t.strstart++;if(i&&(N(t,!1),0===t.strm.avail_out))return A}return t.insert=t.strstart<x-1?t.strstart:x-1,e===f?(N(t,!0),0===t.strm.avail_out?O:B):t.last_lit&&(N(t,!1),0===t.strm.avail_out)?A:I}function W(t,e){for(var r,i,n;;){if(t.lookahead<z){if(j(t),t.lookahead<z&&e===l)return A;if(0===t.lookahead)break}if(r=0,t.lookahead>=x&&(t.ins_h=(t.ins_h<<t.hash_shift^t.window[t.strstart+x-1])&t.hash_mask,r=t.prev[t.strstart&t.w_mask]=t.head[t.ins_h],t.head[t.ins_h]=t.strstart),t.prev_length=t.match_length,t.prev_match=t.match_start,t.match_length=x-1,0!==r&&t.prev_length<t.max_lazy_match&&t.strstart-r<=t.w_size-z&&(t.match_length=L(t,r),t.match_length<=5&&(1===t.strategy||t.match_length===x&&4096<t.strstart-t.match_start)&&(t.match_length=x-1)),t.prev_length>=x&&t.match_length<=t.prev_length){for(n=t.strstart+t.lookahead-x,i=u._tr_tally(t,t.strstart-1-t.prev_match,t.prev_length-x),t.lookahead-=t.prev_length-1,t.prev_length-=2;++t.strstart<=n&&(t.ins_h=(t.ins_h<<t.hash_shift^t.window[t.strstart+x-1])&t.hash_mask,r=t.prev[t.strstart&t.w_mask]=t.head[t.ins_h],t.head[t.ins_h]=t.strstart),0!=--t.prev_length;);if(t.match_available=0,t.match_length=x-1,t.strstart++,i&&(N(t,!1),0===t.strm.avail_out))return A}else if(t.match_available){if((i=u._tr_tally(t,0,t.window[t.strstart-1]))&&N(t,!1),t.strstart++,t.lookahead--,0===t.strm.avail_out)return A}else t.match_available=1,t.strstart++,t.lookahead--}return t.match_available&&(i=u._tr_tally(t,0,t.window[t.strstart-1]),t.match_available=0),t.insert=t.strstart<x-1?t.strstart:x-1,e===f?(N(t,!0),0===t.strm.avail_out?O:B):t.last_lit&&(N(t,!1),0===t.strm.avail_out)?A:I}function M(t,e,r,i,n){this.good_length=t,this.max_lazy=e,this.nice_length=r,this.max_chain=i,this.func=n}function H(){this.strm=null,this.status=0,this.pending_buf=null,this.pending_buf_size=0,this.pending_out=0,this.pending=0,this.wrap=0,this.gzhead=null,this.gzindex=0,this.method=v,this.last_flush=-1,this.w_size=0,this.w_bits=0,this.w_mask=0,this.window=null,this.window_size=0,this.prev=null,this.head=null,this.ins_h=0,this.hash_size=0,this.hash_bits=0,this.hash_mask=0,this.hash_shift=0,this.block_start=0,this.match_length=0,this.prev_match=0,this.match_available=0,this.strstart=0,this.match_start=0,this.lookahead=0,this.prev_length=0,this.max_chain_length=0,this.max_lazy_match=0,this.level=0,this.strategy=0,this.good_match=0,this.nice_match=0,this.dyn_ltree=new d.Buf16(2*w),this.dyn_dtree=new d.Buf16(2*(2*a+1)),this.bl_tree=new d.Buf16(2*(2*o+1)),D(this.dyn_ltree),D(this.dyn_dtree),D(this.bl_tree),this.l_desc=null,this.d_desc=null,this.bl_desc=null,this.bl_count=new d.Buf16(k+1),this.heap=new d.Buf16(2*s+1),D(this.heap),this.heap_len=0,this.heap_max=0,this.depth=new d.Buf16(2*s+1),D(this.depth),this.l_buf=0,this.lit_bufsize=0,this.last_lit=0,this.d_buf=0,this.opt_len=0,this.static_len=0,this.matches=0,this.insert=0,this.bi_buf=0,this.bi_valid=0}function G(t){var e;return t&&t.state?(t.total_in=t.total_out=0,t.data_type=n,(e=t.state).pending=0,e.pending_out=0,e.wrap<0&&(e.wrap=-e.wrap),e.status=e.wrap?C:E,t.adler=2===e.wrap?0:1,e.last_flush=l,u._tr_init(e),m):R(t,_)}function K(t){var e=G(t);return e===m&&function(t){t.window_size=2*t.w_size,D(t.head),t.max_lazy_match=h[t.level].max_lazy,t.good_match=h[t.level].good_length,t.nice_match=h[t.level].nice_length,t.max_chain_length=h[t.level].max_chain,t.strstart=0,t.block_start=0,t.lookahead=0,t.insert=0,t.match_length=t.prev_length=x-1,t.match_available=0,t.ins_h=0}(t.state),e}function Y(t,e,r,i,n,s){if(!t)return _;var a=1;if(e===g&&(e=6),i<0?(a=0,i=-i):15<i&&(a=2,i-=16),n<1||y<n||r!==v||i<8||15<i||e<0||9<e||s<0||b<s)return R(t,_);8===i&&(i=9);var o=new H;return(t.state=o).strm=t,o.wrap=a,o.gzhead=null,o.w_bits=i,o.w_size=1<<o.w_bits,o.w_mask=o.w_size-1,o.hash_bits=n+7,o.hash_size=1<<o.hash_bits,o.hash_mask=o.hash_size-1,o.hash_shift=~~((o.hash_bits+x-1)/x),o.window=new d.Buf8(2*o.w_size),o.head=new d.Buf16(o.hash_size),o.prev=new d.Buf16(o.w_size),o.lit_bufsize=1<<n+6,o.pending_buf_size=4*o.lit_bufsize,o.pending_buf=new d.Buf8(o.pending_buf_size),o.d_buf=1*o.lit_bufsize,o.l_buf=3*o.lit_bufsize,o.level=e,o.strategy=s,o.method=r,K(t)}h=[new M(0,0,0,0,function(t,e){var r=65535;for(r>t.pending_buf_size-5&&(r=t.pending_buf_size-5);;){if(t.lookahead<=1){if(j(t),0===t.lookahead&&e===l)return A;if(0===t.lookahead)break}t.strstart+=t.lookahead,t.lookahead=0;var i=t.block_start+r;if((0===t.strstart||t.strstart>=i)&&(t.lookahead=t.strstart-i,t.strstart=i,N(t,!1),0===t.strm.avail_out))return A;if(t.strstart-t.block_start>=t.w_size-z&&(N(t,!1),0===t.strm.avail_out))return A}return t.insert=0,e===f?(N(t,!0),0===t.strm.avail_out?O:B):(t.strstart>t.block_start&&(N(t,!1),t.strm.avail_out),A)}),new M(4,4,8,4,Z),new M(4,5,16,8,Z),new M(4,6,32,32,Z),new M(4,4,16,16,W),new M(8,16,32,32,W),new M(8,16,128,128,W),new M(8,32,128,256,W),new M(32,128,258,1024,W),new M(32,258,258,4096,W)],r.deflateInit=function(t,e){return Y(t,e,v,15,8,0)},r.deflateInit2=Y,r.deflateReset=K,r.deflateResetKeep=G,r.deflateSetHeader=function(t,e){return t&&t.state?2!==t.state.wrap?_:(t.state.gzhead=e,m):_},r.deflate=function(t,e){var r,i,n,s;if(!t||!t.state||5<e||e<0)return t?R(t,_):_;if(i=t.state,!t.output||!t.input&&0!==t.avail_in||666===i.status&&e!==f)return R(t,0===t.avail_out?-5:_);if(i.strm=t,r=i.last_flush,i.last_flush=e,i.status===C)if(2===i.wrap)t.adler=0,U(i,31),U(i,139),U(i,8),i.gzhead?(U(i,(i.gzhead.text?1:0)+(i.gzhead.hcrc?2:0)+(i.gzhead.extra?4:0)+(i.gzhead.name?8:0)+(i.gzhead.comment?16:0)),U(i,255&i.gzhead.time),U(i,i.gzhead.time>>8&255),U(i,i.gzhead.time>>16&255),U(i,i.gzhead.time>>24&255),U(i,9===i.level?2:2<=i.strategy||i.level<2?4:0),U(i,255&i.gzhead.os),i.gzhead.extra&&i.gzhead.extra.length&&(U(i,255&i.gzhead.extra.length),U(i,i.gzhead.extra.length>>8&255)),i.gzhead.hcrc&&(t.adler=p(t.adler,i.pending_buf,i.pending,0)),i.gzindex=0,i.status=69):(U(i,0),U(i,0),U(i,0),U(i,0),U(i,0),U(i,9===i.level?2:2<=i.strategy||i.level<2?4:0),U(i,3),i.status=E);else{var a=v+(i.w_bits-8<<4)<<8;a|=(2<=i.strategy||i.level<2?0:i.level<6?1:6===i.level?2:3)<<6,0!==i.strstart&&(a|=32),a+=31-a%31,i.status=E,P(i,a),0!==i.strstart&&(P(i,t.adler>>>16),P(i,65535&t.adler)),t.adler=1}if(69===i.status)if(i.gzhead.extra){for(n=i.pending;i.gzindex<(65535&i.gzhead.extra.length)&&(i.pending!==i.pending_buf_size||(i.gzhead.hcrc&&i.pending>n&&(t.adler=p(t.adler,i.pending_buf,i.pending-n,n)),F(t),n=i.pending,i.pending!==i.pending_buf_size));)U(i,255&i.gzhead.extra[i.gzindex]),i.gzindex++;i.gzhead.hcrc&&i.pending>n&&(t.adler=p(t.adler,i.pending_buf,i.pending-n,n)),i.gzindex===i.gzhead.extra.length&&(i.gzindex=0,i.status=73)}else i.status=73;if(73===i.status)if(i.gzhead.name){n=i.pending;do{if(i.pending===i.pending_buf_size&&(i.gzhead.hcrc&&i.pending>n&&(t.adler=p(t.adler,i.pending_buf,i.pending-n,n)),F(t),n=i.pending,i.pending===i.pending_buf_size)){s=1;break}s=i.gzindex<i.gzhead.name.length?255&i.gzhead.name.charCodeAt(i.gzindex++):0,U(i,s)}while(0!==s);i.gzhead.hcrc&&i.pending>n&&(t.adler=p(t.adler,i.pending_buf,i.pending-n,n)),0===s&&(i.gzindex=0,i.status=91)}else i.status=91;if(91===i.status)if(i.gzhead.comment){n=i.pending;do{if(i.pending===i.pending_buf_size&&(i.gzhead.hcrc&&i.pending>n&&(t.adler=p(t.adler,i.pending_buf,i.pending-n,n)),F(t),n=i.pending,i.pending===i.pending_buf_size)){s=1;break}s=i.gzindex<i.gzhead.comment.length?255&i.gzhead.comment.charCodeAt(i.gzindex++):0,U(i,s)}while(0!==s);i.gzhead.hcrc&&i.pending>n&&(t.adler=p(t.adler,i.pending_buf,i.pending-n,n)),0===s&&(i.status=103)}else i.status=103;if(103===i.status&&(i.gzhead.hcrc?(i.pending+2>i.pending_buf_size&&F(t),i.pending+2<=i.pending_buf_size&&(U(i,255&t.adler),U(i,t.adler>>8&255),t.adler=0,i.status=E)):i.status=E),0!==i.pending){if(F(t),0===t.avail_out)return i.last_flush=-1,m}else if(0===t.avail_in&&T(e)<=T(r)&&e!==f)return R(t,-5);if(666===i.status&&0!==t.avail_in)return R(t,-5);if(0!==t.avail_in||0!==i.lookahead||e!==l&&666!==i.status){var o=2===i.strategy?function(t,e){for(var r;;){if(0===t.lookahead&&(j(t),0===t.lookahead)){if(e===l)return A;break}if(t.match_length=0,r=u._tr_tally(t,0,t.window[t.strstart]),t.lookahead--,t.strstart++,r&&(N(t,!1),0===t.strm.avail_out))return A}return t.insert=0,e===f?(N(t,!0),0===t.strm.avail_out?O:B):t.last_lit&&(N(t,!1),0===t.strm.avail_out)?A:I}(i,e):3===i.strategy?function(t,e){for(var r,i,n,s,a=t.window;;){if(t.lookahead<=S){if(j(t),t.lookahead<=S&&e===l)return A;if(0===t.lookahead)break}if(t.match_length=0,t.lookahead>=x&&0<t.strstart&&(i=a[n=t.strstart-1])===a[++n]&&i===a[++n]&&i===a[++n]){s=t.strstart+S;do{}while(i===a[++n]&&i===a[++n]&&i===a[++n]&&i===a[++n]&&i===a[++n]&&i===a[++n]&&i===a[++n]&&i===a[++n]&&n<s);t.match_length=S-(s-n),t.match_length>t.lookahead&&(t.match_length=t.lookahead)}if(t.match_length>=x?(r=u._tr_tally(t,1,t.match_length-x),t.lookahead-=t.match_length,t.strstart+=t.match_length,t.match_length=0):(r=u._tr_tally(t,0,t.window[t.strstart]),t.lookahead--,t.strstart++),r&&(N(t,!1),0===t.strm.avail_out))return A}return t.insert=0,e===f?(N(t,!0),0===t.strm.avail_out?O:B):t.last_lit&&(N(t,!1),0===t.strm.avail_out)?A:I}(i,e):h[i.level].func(i,e);if(o!==O&&o!==B||(i.status=666),o===A||o===O)return 0===t.avail_out&&(i.last_flush=-1),m;if(o===I&&(1===e?u._tr_align(i):5!==e&&(u._tr_stored_block(i,0,0,!1),3===e&&(D(i.head),0===i.lookahead&&(i.strstart=0,i.block_start=0,i.insert=0))),F(t),0===t.avail_out))return i.last_flush=-1,m}return e!==f?m:i.wrap<=0?1:(2===i.wrap?(U(i,255&t.adler),U(i,t.adler>>8&255),U(i,t.adler>>16&255),U(i,t.adler>>24&255),U(i,255&t.total_in),U(i,t.total_in>>8&255),U(i,t.total_in>>16&255),U(i,t.total_in>>24&255)):(P(i,t.adler>>>16),P(i,65535&t.adler)),F(t),0<i.wrap&&(i.wrap=-i.wrap),0!==i.pending?m:1)},r.deflateEnd=function(t){var e;return t&&t.state?(e=t.state.status)!==C&&69!==e&&73!==e&&91!==e&&103!==e&&e!==E&&666!==e?R(t,_):(t.state=null,e===E?R(t,-3):m):_},r.deflateSetDictionary=function(t,e){var r,i,n,s,a,o,h,u,l=e.length;if(!t||!t.state)return _;if(2===(s=(r=t.state).wrap)||1===s&&r.status!==C||r.lookahead)return _;for(1===s&&(t.adler=c(t.adler,e,l,0)),r.wrap=0,l>=r.w_size&&(0===s&&(D(r.head),r.strstart=0,r.block_start=0,r.insert=0),u=new d.Buf8(r.w_size),d.arraySet(u,e,l-r.w_size,r.w_size,0),e=u,l=r.w_size),a=t.avail_in,o=t.next_in,h=t.input,t.avail_in=l,t.next_in=0,t.input=e,j(r);r.lookahead>=x;){for(i=r.strstart,n=r.lookahead-(x-1);r.ins_h=(r.ins_h<<r.hash_shift^r.window[i+x-1])&r.hash_mask,r.prev[i&r.w_mask]=r.head[r.ins_h],r.head[r.ins_h]=i,i++,--n;);r.strstart=i,r.lookahead=x-1,j(r)}return r.strstart+=r.lookahead,r.block_start=r.strstart,r.insert=r.lookahead,r.lookahead=0,r.match_length=r.prev_length=x-1,r.match_available=0,t.next_in=o,t.input=h,t.avail_in=a,r.wrap=s,m},r.deflateInfo="pako deflate (from Nodeca project)"},{"../utils/common":41,"./adler32":43,"./crc32":45,"./messages":51,"./trees":52}],47:[function(t,e,r){"use strict";e.exports=function(){this.text=0,this.time=0,this.xflags=0,this.os=0,this.extra=null,this.extra_len=0,this.name="",this.comment="",this.hcrc=0,this.done=!1}},{}],48:[function(t,e,r){"use strict";e.exports=function(t,e){var r,i,n,s,a,o,h,u,l,f,d,c,p,m,_,g,b,v,y,w,k,x,S,z,C;r=t.state,i=t.next_in,z=t.input,n=i+(t.avail_in-5),s=t.next_out,C=t.output,a=s-(e-t.avail_out),o=s+(t.avail_out-257),h=r.dmax,u=r.wsize,l=r.whave,f=r.wnext,d=r.window,c=r.hold,p=r.bits,m=r.lencode,_=r.distcode,g=(1<<r.lenbits)-1,b=(1<<r.distbits)-1;t:do{p<15&&(c+=z[i++]<<p,p+=8,c+=z[i++]<<p,p+=8),v=m[c&g];e:for(;;){if(c>>>=y=v>>>24,p-=y,0===(y=v>>>16&255))C[s++]=65535&v;else{if(!(16&y)){if(0==(64&y)){v=m[(65535&v)+(c&(1<<y)-1)];continue e}if(32&y){r.mode=12;break t}t.msg="invalid literal/length code",r.mode=30;break t}w=65535&v,(y&=15)&&(p<y&&(c+=z[i++]<<p,p+=8),w+=c&(1<<y)-1,c>>>=y,p-=y),p<15&&(c+=z[i++]<<p,p+=8,c+=z[i++]<<p,p+=8),v=_[c&b];r:for(;;){if(c>>>=y=v>>>24,p-=y,!(16&(y=v>>>16&255))){if(0==(64&y)){v=_[(65535&v)+(c&(1<<y)-1)];continue r}t.msg="invalid distance code",r.mode=30;break t}if(k=65535&v,p<(y&=15)&&(c+=z[i++]<<p,(p+=8)<y&&(c+=z[i++]<<p,p+=8)),h<(k+=c&(1<<y)-1)){t.msg="invalid distance too far back",r.mode=30;break t}if(c>>>=y,p-=y,(y=s-a)<k){if(l<(y=k-y)&&r.sane){t.msg="invalid distance too far back",r.mode=30;break t}if(S=d,(x=0)===f){if(x+=u-y,y<w){for(w-=y;C[s++]=d[x++],--y;);x=s-k,S=C}}else if(f<y){if(x+=u+f-y,(y-=f)<w){for(w-=y;C[s++]=d[x++],--y;);if(x=0,f<w){for(w-=y=f;C[s++]=d[x++],--y;);x=s-k,S=C}}}else if(x+=f-y,y<w){for(w-=y;C[s++]=d[x++],--y;);x=s-k,S=C}for(;2<w;)C[s++]=S[x++],C[s++]=S[x++],C[s++]=S[x++],w-=3;w&&(C[s++]=S[x++],1<w&&(C[s++]=S[x++]))}else{for(x=s-k;C[s++]=C[x++],C[s++]=C[x++],C[s++]=C[x++],2<(w-=3););w&&(C[s++]=C[x++],1<w&&(C[s++]=C[x++]))}break}}break}}while(i<n&&s<o);i-=w=p>>3,c&=(1<<(p-=w<<3))-1,t.next_in=i,t.next_out=s,t.avail_in=i<n?n-i+5:5-(i-n),t.avail_out=s<o?o-s+257:257-(s-o),r.hold=c,r.bits=p}},{}],49:[function(t,e,r){"use strict";var I=t("../utils/common"),O=t("./adler32"),B=t("./crc32"),R=t("./inffast"),T=t("./inftrees"),D=1,F=2,N=0,U=-2,P=1,i=852,n=592;function L(t){return(t>>>24&255)+(t>>>8&65280)+((65280&t)<<8)+((255&t)<<24)}function s(){this.mode=0,this.last=!1,this.wrap=0,this.havedict=!1,this.flags=0,this.dmax=0,this.check=0,this.total=0,this.head=null,this.wbits=0,this.wsize=0,this.whave=0,this.wnext=0,this.window=null,this.hold=0,this.bits=0,this.length=0,this.offset=0,this.extra=0,this.lencode=null,this.distcode=null,this.lenbits=0,this.distbits=0,this.ncode=0,this.nlen=0,this.ndist=0,this.have=0,this.next=null,this.lens=new I.Buf16(320),this.work=new I.Buf16(288),this.lendyn=null,this.distdyn=null,this.sane=0,this.back=0,this.was=0}function a(t){var e;return t&&t.state?(e=t.state,t.total_in=t.total_out=e.total=0,t.msg="",e.wrap&&(t.adler=1&e.wrap),e.mode=P,e.last=0,e.havedict=0,e.dmax=32768,e.head=null,e.hold=0,e.bits=0,e.lencode=e.lendyn=new I.Buf32(i),e.distcode=e.distdyn=new I.Buf32(n),e.sane=1,e.back=-1,N):U}function o(t){var e;return t&&t.state?((e=t.state).wsize=0,e.whave=0,e.wnext=0,a(t)):U}function h(t,e){var r,i;return t&&t.state?(i=t.state,e<0?(r=0,e=-e):(r=1+(e>>4),e<48&&(e&=15)),e&&(e<8||15<e)?U:(null!==i.window&&i.wbits!==e&&(i.window=null),i.wrap=r,i.wbits=e,o(t))):U}function u(t,e){var r,i;return t?(i=new s,(t.state=i).window=null,(r=h(t,e))!==N&&(t.state=null),r):U}var l,f,d=!0;function j(t){if(d){var e;for(l=new I.Buf32(512),f=new I.Buf32(32),e=0;e<144;)t.lens[e++]=8;for(;e<256;)t.lens[e++]=9;for(;e<280;)t.lens[e++]=7;for(;e<288;)t.lens[e++]=8;for(T(D,t.lens,0,288,l,0,t.work,{bits:9}),e=0;e<32;)t.lens[e++]=5;T(F,t.lens,0,32,f,0,t.work,{bits:5}),d=!1}t.lencode=l,t.lenbits=9,t.distcode=f,t.distbits=5}function Z(t,e,r,i){var n,s=t.state;return null===s.window&&(s.wsize=1<<s.wbits,s.wnext=0,s.whave=0,s.window=new I.Buf8(s.wsize)),i>=s.wsize?(I.arraySet(s.window,e,r-s.wsize,s.wsize,0),s.wnext=0,s.whave=s.wsize):(i<(n=s.wsize-s.wnext)&&(n=i),I.arraySet(s.window,e,r-i,n,s.wnext),(i-=n)?(I.arraySet(s.window,e,r-i,i,0),s.wnext=i,s.whave=s.wsize):(s.wnext+=n,s.wnext===s.wsize&&(s.wnext=0),s.whave<s.wsize&&(s.whave+=n))),0}r.inflateReset=o,r.inflateReset2=h,r.inflateResetKeep=a,r.inflateInit=function(t){return u(t,15)},r.inflateInit2=u,r.inflate=function(t,e){var r,i,n,s,a,o,h,u,l,f,d,c,p,m,_,g,b,v,y,w,k,x,S,z,C=0,E=new I.Buf8(4),A=[16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15];if(!t||!t.state||!t.output||!t.input&&0!==t.avail_in)return U;12===(r=t.state).mode&&(r.mode=13),a=t.next_out,n=t.output,h=t.avail_out,s=t.next_in,i=t.input,o=t.avail_in,u=r.hold,l=r.bits,f=o,d=h,x=N;t:for(;;)switch(r.mode){case P:if(0===r.wrap){r.mode=13;break}for(;l<16;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}if(2&r.wrap&&35615===u){E[r.check=0]=255&u,E[1]=u>>>8&255,r.check=B(r.check,E,2,0),l=u=0,r.mode=2;break}if(r.flags=0,r.head&&(r.head.done=!1),!(1&r.wrap)||(((255&u)<<8)+(u>>8))%31){t.msg="incorrect header check",r.mode=30;break}if(8!=(15&u)){t.msg="unknown compression method",r.mode=30;break}if(l-=4,k=8+(15&(u>>>=4)),0===r.wbits)r.wbits=k;else if(k>r.wbits){t.msg="invalid window size",r.mode=30;break}r.dmax=1<<k,t.adler=r.check=1,r.mode=512&u?10:12,l=u=0;break;case 2:for(;l<16;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}if(r.flags=u,8!=(255&r.flags)){t.msg="unknown compression method",r.mode=30;break}if(57344&r.flags){t.msg="unknown header flags set",r.mode=30;break}r.head&&(r.head.text=u>>8&1),512&r.flags&&(E[0]=255&u,E[1]=u>>>8&255,r.check=B(r.check,E,2,0)),l=u=0,r.mode=3;case 3:for(;l<32;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}r.head&&(r.head.time=u),512&r.flags&&(E[0]=255&u,E[1]=u>>>8&255,E[2]=u>>>16&255,E[3]=u>>>24&255,r.check=B(r.check,E,4,0)),l=u=0,r.mode=4;case 4:for(;l<16;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}r.head&&(r.head.xflags=255&u,r.head.os=u>>8),512&r.flags&&(E[0]=255&u,E[1]=u>>>8&255,r.check=B(r.check,E,2,0)),l=u=0,r.mode=5;case 5:if(1024&r.flags){for(;l<16;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}r.length=u,r.head&&(r.head.extra_len=u),512&r.flags&&(E[0]=255&u,E[1]=u>>>8&255,r.check=B(r.check,E,2,0)),l=u=0}else r.head&&(r.head.extra=null);r.mode=6;case 6:if(1024&r.flags&&(o<(c=r.length)&&(c=o),c&&(r.head&&(k=r.head.extra_len-r.length,r.head.extra||(r.head.extra=new Array(r.head.extra_len)),I.arraySet(r.head.extra,i,s,c,k)),512&r.flags&&(r.check=B(r.check,i,c,s)),o-=c,s+=c,r.length-=c),r.length))break t;r.length=0,r.mode=7;case 7:if(2048&r.flags){if(0===o)break t;for(c=0;k=i[s+c++],r.head&&k&&r.length<65536&&(r.head.name+=String.fromCharCode(k)),k&&c<o;);if(512&r.flags&&(r.check=B(r.check,i,c,s)),o-=c,s+=c,k)break t}else r.head&&(r.head.name=null);r.length=0,r.mode=8;case 8:if(4096&r.flags){if(0===o)break t;for(c=0;k=i[s+c++],r.head&&k&&r.length<65536&&(r.head.comment+=String.fromCharCode(k)),k&&c<o;);if(512&r.flags&&(r.check=B(r.check,i,c,s)),o-=c,s+=c,k)break t}else r.head&&(r.head.comment=null);r.mode=9;case 9:if(512&r.flags){for(;l<16;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}if(u!==(65535&r.check)){t.msg="header crc mismatch",r.mode=30;break}l=u=0}r.head&&(r.head.hcrc=r.flags>>9&1,r.head.done=!0),t.adler=r.check=0,r.mode=12;break;case 10:for(;l<32;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}t.adler=r.check=L(u),l=u=0,r.mode=11;case 11:if(0===r.havedict)return t.next_out=a,t.avail_out=h,t.next_in=s,t.avail_in=o,r.hold=u,r.bits=l,2;t.adler=r.check=1,r.mode=12;case 12:if(5===e||6===e)break t;case 13:if(r.last){u>>>=7&l,l-=7&l,r.mode=27;break}for(;l<3;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}switch(r.last=1&u,l-=1,3&(u>>>=1)){case 0:r.mode=14;break;case 1:if(j(r),r.mode=20,6!==e)break;u>>>=2,l-=2;break t;case 2:r.mode=17;break;case 3:t.msg="invalid block type",r.mode=30}u>>>=2,l-=2;break;case 14:for(u>>>=7&l,l-=7&l;l<32;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}if((65535&u)!=(u>>>16^65535)){t.msg="invalid stored block lengths",r.mode=30;break}if(r.length=65535&u,l=u=0,r.mode=15,6===e)break t;case 15:r.mode=16;case 16:if(c=r.length){if(o<c&&(c=o),h<c&&(c=h),0===c)break t;I.arraySet(n,i,s,c,a),o-=c,s+=c,h-=c,a+=c,r.length-=c;break}r.mode=12;break;case 17:for(;l<14;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}if(r.nlen=257+(31&u),u>>>=5,l-=5,r.ndist=1+(31&u),u>>>=5,l-=5,r.ncode=4+(15&u),u>>>=4,l-=4,286<r.nlen||30<r.ndist){t.msg="too many length or distance symbols",r.mode=30;break}r.have=0,r.mode=18;case 18:for(;r.have<r.ncode;){for(;l<3;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}r.lens[A[r.have++]]=7&u,u>>>=3,l-=3}for(;r.have<19;)r.lens[A[r.have++]]=0;if(r.lencode=r.lendyn,r.lenbits=7,S={bits:r.lenbits},x=T(0,r.lens,0,19,r.lencode,0,r.work,S),r.lenbits=S.bits,x){t.msg="invalid code lengths set",r.mode=30;break}r.have=0,r.mode=19;case 19:for(;r.have<r.nlen+r.ndist;){for(;g=(C=r.lencode[u&(1<<r.lenbits)-1])>>>16&255,b=65535&C,!((_=C>>>24)<=l);){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}if(b<16)u>>>=_,l-=_,r.lens[r.have++]=b;else{if(16===b){for(z=_+2;l<z;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}if(u>>>=_,l-=_,0===r.have){t.msg="invalid bit length repeat",r.mode=30;break}k=r.lens[r.have-1],c=3+(3&u),u>>>=2,l-=2}else if(17===b){for(z=_+3;l<z;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}l-=_,k=0,c=3+(7&(u>>>=_)),u>>>=3,l-=3}else{for(z=_+7;l<z;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}l-=_,k=0,c=11+(127&(u>>>=_)),u>>>=7,l-=7}if(r.have+c>r.nlen+r.ndist){t.msg="invalid bit length repeat",r.mode=30;break}for(;c--;)r.lens[r.have++]=k}}if(30===r.mode)break;if(0===r.lens[256]){t.msg="invalid code -- missing end-of-block",r.mode=30;break}if(r.lenbits=9,S={bits:r.lenbits},x=T(D,r.lens,0,r.nlen,r.lencode,0,r.work,S),r.lenbits=S.bits,x){t.msg="invalid literal/lengths set",r.mode=30;break}if(r.distbits=6,r.distcode=r.distdyn,S={bits:r.distbits},x=T(F,r.lens,r.nlen,r.ndist,r.distcode,0,r.work,S),r.distbits=S.bits,x){t.msg="invalid distances set",r.mode=30;break}if(r.mode=20,6===e)break t;case 20:r.mode=21;case 21:if(6<=o&&258<=h){t.next_out=a,t.avail_out=h,t.next_in=s,t.avail_in=o,r.hold=u,r.bits=l,R(t,d),a=t.next_out,n=t.output,h=t.avail_out,s=t.next_in,i=t.input,o=t.avail_in,u=r.hold,l=r.bits,12===r.mode&&(r.back=-1);break}for(r.back=0;g=(C=r.lencode[u&(1<<r.lenbits)-1])>>>16&255,b=65535&C,!((_=C>>>24)<=l);){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}if(g&&0==(240&g)){for(v=_,y=g,w=b;g=(C=r.lencode[w+((u&(1<<v+y)-1)>>v)])>>>16&255,b=65535&C,!(v+(_=C>>>24)<=l);){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}u>>>=v,l-=v,r.back+=v}if(u>>>=_,l-=_,r.back+=_,r.length=b,0===g){r.mode=26;break}if(32&g){r.back=-1,r.mode=12;break}if(64&g){t.msg="invalid literal/length code",r.mode=30;break}r.extra=15&g,r.mode=22;case 22:if(r.extra){for(z=r.extra;l<z;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}r.length+=u&(1<<r.extra)-1,u>>>=r.extra,l-=r.extra,r.back+=r.extra}r.was=r.length,r.mode=23;case 23:for(;g=(C=r.distcode[u&(1<<r.distbits)-1])>>>16&255,b=65535&C,!((_=C>>>24)<=l);){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}if(0==(240&g)){for(v=_,y=g,w=b;g=(C=r.distcode[w+((u&(1<<v+y)-1)>>v)])>>>16&255,b=65535&C,!(v+(_=C>>>24)<=l);){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}u>>>=v,l-=v,r.back+=v}if(u>>>=_,l-=_,r.back+=_,64&g){t.msg="invalid distance code",r.mode=30;break}r.offset=b,r.extra=15&g,r.mode=24;case 24:if(r.extra){for(z=r.extra;l<z;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}r.offset+=u&(1<<r.extra)-1,u>>>=r.extra,l-=r.extra,r.back+=r.extra}if(r.offset>r.dmax){t.msg="invalid distance too far back",r.mode=30;break}r.mode=25;case 25:if(0===h)break t;if(c=d-h,r.offset>c){if((c=r.offset-c)>r.whave&&r.sane){t.msg="invalid distance too far back",r.mode=30;break}p=c>r.wnext?(c-=r.wnext,r.wsize-c):r.wnext-c,c>r.length&&(c=r.length),m=r.window}else m=n,p=a-r.offset,c=r.length;for(h<c&&(c=h),h-=c,r.length-=c;n[a++]=m[p++],--c;);0===r.length&&(r.mode=21);break;case 26:if(0===h)break t;n[a++]=r.length,h--,r.mode=21;break;case 27:if(r.wrap){for(;l<32;){if(0===o)break t;o--,u|=i[s++]<<l,l+=8}if(d-=h,t.total_out+=d,r.total+=d,d&&(t.adler=r.check=r.flags?B(r.check,n,d,a-d):O(r.check,n,d,a-d)),d=h,(r.flags?u:L(u))!==r.check){t.msg="incorrect data check",r.mode=30;break}l=u=0}r.mode=28;case 28:if(r.wrap&&r.flags){for(;l<32;){if(0===o)break t;o--,u+=i[s++]<<l,l+=8}if(u!==(4294967295&r.total)){t.msg="incorrect length check",r.mode=30;break}l=u=0}r.mode=29;case 29:x=1;break t;case 30:x=-3;break t;case 31:return-4;case 32:default:return U}return t.next_out=a,t.avail_out=h,t.next_in=s,t.avail_in=o,r.hold=u,r.bits=l,(r.wsize||d!==t.avail_out&&r.mode<30&&(r.mode<27||4!==e))&&Z(t,t.output,t.next_out,d-t.avail_out)?(r.mode=31,-4):(f-=t.avail_in,d-=t.avail_out,t.total_in+=f,t.total_out+=d,r.total+=d,r.wrap&&d&&(t.adler=r.check=r.flags?B(r.check,n,d,t.next_out-d):O(r.check,n,d,t.next_out-d)),t.data_type=r.bits+(r.last?64:0)+(12===r.mode?128:0)+(20===r.mode||15===r.mode?256:0),(0==f&&0===d||4===e)&&x===N&&(x=-5),x)},r.inflateEnd=function(t){if(!t||!t.state)return U;var e=t.state;return e.window&&(e.window=null),t.state=null,N},r.inflateGetHeader=function(t,e){var r;return t&&t.state?0==(2&(r=t.state).wrap)?U:((r.head=e).done=!1,N):U},r.inflateSetDictionary=function(t,e){var r,i=e.length;return t&&t.state?0!==(r=t.state).wrap&&11!==r.mode?U:11===r.mode&&O(1,e,i,0)!==r.check?-3:Z(t,e,i,i)?(r.mode=31,-4):(r.havedict=1,N):U},r.inflateInfo="pako inflate (from Nodeca project)"},{"../utils/common":41,"./adler32":43,"./crc32":45,"./inffast":48,"./inftrees":50}],50:[function(t,e,r){"use strict";var D=t("../utils/common"),F=[3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0],N=[16,16,16,16,16,16,16,16,17,17,17,17,18,18,18,18,19,19,19,19,20,20,20,20,21,21,21,21,16,72,78],U=[1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577,0,0],P=[16,16,16,16,17,17,18,18,19,19,20,20,21,21,22,22,23,23,24,24,25,25,26,26,27,27,28,28,29,29,64,64];e.exports=function(t,e,r,i,n,s,a,o){var h,u,l,f,d,c,p,m,_,g=o.bits,b=0,v=0,y=0,w=0,k=0,x=0,S=0,z=0,C=0,E=0,A=null,I=0,O=new D.Buf16(16),B=new D.Buf16(16),R=null,T=0;for(b=0;b<=15;b++)O[b]=0;for(v=0;v<i;v++)O[e[r+v]]++;for(k=g,w=15;1<=w&&0===O[w];w--);if(w<k&&(k=w),0===w)return n[s++]=20971520,n[s++]=20971520,o.bits=1,0;for(y=1;y<w&&0===O[y];y++);for(k<y&&(k=y),b=z=1;b<=15;b++)if(z<<=1,(z-=O[b])<0)return-1;if(0<z&&(0===t||1!==w))return-1;for(B[1]=0,b=1;b<15;b++)B[b+1]=B[b]+O[b];for(v=0;v<i;v++)0!==e[r+v]&&(a[B[e[r+v]]++]=v);if(c=0===t?(A=R=a,19):1===t?(A=F,I-=257,R=N,T-=257,256):(A=U,R=P,-1),b=y,d=s,S=v=E=0,l=-1,f=(C=1<<(x=k))-1,1===t&&852<C||2===t&&592<C)return 1;for(;;){for(p=b-S,_=a[v]<c?(m=0,a[v]):a[v]>c?(m=R[T+a[v]],A[I+a[v]]):(m=96,0),h=1<<b-S,y=u=1<<x;n[d+(E>>S)+(u-=h)]=p<<24|m<<16|_|0,0!==u;);for(h=1<<b-1;E&h;)h>>=1;if(0!==h?(E&=h-1,E+=h):E=0,v++,0==--O[b]){if(b===w)break;b=e[r+a[v]]}if(k<b&&(E&f)!==l){for(0===S&&(S=k),d+=y,z=1<<(x=b-S);x+S<w&&!((z-=O[x+S])<=0);)x++,z<<=1;if(C+=1<<x,1===t&&852<C||2===t&&592<C)return 1;n[l=E&f]=k<<24|x<<16|d-s|0}}return 0!==E&&(n[d+E]=b-S<<24|64<<16|0),o.bits=k,0}},{"../utils/common":41}],51:[function(t,e,r){"use strict";e.exports={2:"need dictionary",1:"stream end",0:"","-1":"file error","-2":"stream error","-3":"data error","-4":"insufficient memory","-5":"buffer error","-6":"incompatible version"}},{}],52:[function(t,e,r){"use strict";var n=t("../utils/common"),o=0,h=1;function i(t){for(var e=t.length;0<=--e;)t[e]=0}var s=0,a=29,u=256,l=u+1+a,f=30,d=19,_=2*l+1,g=15,c=16,p=7,m=256,b=16,v=17,y=18,w=[0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0],k=[0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13],x=[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,3,7],S=[16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15],z=new Array(2*(l+2));i(z);var C=new Array(2*f);i(C);var E=new Array(512);i(E);var A=new Array(256);i(A);var I=new Array(a);i(I);var O,B,R,T=new Array(f);function D(t,e,r,i,n){this.static_tree=t,this.extra_bits=e,this.extra_base=r,this.elems=i,this.max_length=n,this.has_stree=t&&t.length}function F(t,e){this.dyn_tree=t,this.max_code=0,this.stat_desc=e}function N(t){return t<256?E[t]:E[256+(t>>>7)]}function U(t,e){t.pending_buf[t.pending++]=255&e,t.pending_buf[t.pending++]=e>>>8&255}function P(t,e,r){t.bi_valid>c-r?(t.bi_buf|=e<<t.bi_valid&65535,U(t,t.bi_buf),t.bi_buf=e>>c-t.bi_valid,t.bi_valid+=r-c):(t.bi_buf|=e<<t.bi_valid&65535,t.bi_valid+=r)}function L(t,e,r){P(t,r[2*e],r[2*e+1])}function j(t,e){for(var r=0;r|=1&t,t>>>=1,r<<=1,0<--e;);return r>>>1}function Z(t,e,r){var i,n,s=new Array(g+1),a=0;for(i=1;i<=g;i++)s[i]=a=a+r[i-1]<<1;for(n=0;n<=e;n++){var o=t[2*n+1];0!==o&&(t[2*n]=j(s[o]++,o))}}function W(t){var e;for(e=0;e<l;e++)t.dyn_ltree[2*e]=0;for(e=0;e<f;e++)t.dyn_dtree[2*e]=0;for(e=0;e<d;e++)t.bl_tree[2*e]=0;t.dyn_ltree[2*m]=1,t.opt_len=t.static_len=0,t.last_lit=t.matches=0}function M(t){8<t.bi_valid?U(t,t.bi_buf):0<t.bi_valid&&(t.pending_buf[t.pending++]=t.bi_buf),t.bi_buf=0,t.bi_valid=0}function H(t,e,r,i){var n=2*e,s=2*r;return t[n]<t[s]||t[n]===t[s]&&i[e]<=i[r]}function G(t,e,r){for(var i=t.heap[r],n=r<<1;n<=t.heap_len&&(n<t.heap_len&&H(e,t.heap[n+1],t.heap[n],t.depth)&&n++,!H(e,i,t.heap[n],t.depth));)t.heap[r]=t.heap[n],r=n,n<<=1;t.heap[r]=i}function K(t,e,r){var i,n,s,a,o=0;if(0!==t.last_lit)for(;i=t.pending_buf[t.d_buf+2*o]<<8|t.pending_buf[t.d_buf+2*o+1],n=t.pending_buf[t.l_buf+o],o++,0===i?L(t,n,e):(L(t,(s=A[n])+u+1,e),0!==(a=w[s])&&P(t,n-=I[s],a),L(t,s=N(--i),r),0!==(a=k[s])&&P(t,i-=T[s],a)),o<t.last_lit;);L(t,m,e)}function Y(t,e){var r,i,n,s=e.dyn_tree,a=e.stat_desc.static_tree,o=e.stat_desc.has_stree,h=e.stat_desc.elems,u=-1;for(t.heap_len=0,t.heap_max=_,r=0;r<h;r++)0!==s[2*r]?(t.heap[++t.heap_len]=u=r,t.depth[r]=0):s[2*r+1]=0;for(;t.heap_len<2;)s[2*(n=t.heap[++t.heap_len]=u<2?++u:0)]=1,t.depth[n]=0,t.opt_len--,o&&(t.static_len-=a[2*n+1]);for(e.max_code=u,r=t.heap_len>>1;1<=r;r--)G(t,s,r);for(n=h;r=t.heap[1],t.heap[1]=t.heap[t.heap_len--],G(t,s,1),i=t.heap[1],t.heap[--t.heap_max]=r,t.heap[--t.heap_max]=i,s[2*n]=s[2*r]+s[2*i],t.depth[n]=(t.depth[r]>=t.depth[i]?t.depth[r]:t.depth[i])+1,s[2*r+1]=s[2*i+1]=n,t.heap[1]=n++,G(t,s,1),2<=t.heap_len;);t.heap[--t.heap_max]=t.heap[1],function(t,e){var r,i,n,s,a,o,h=e.dyn_tree,u=e.max_code,l=e.stat_desc.static_tree,f=e.stat_desc.has_stree,d=e.stat_desc.extra_bits,c=e.stat_desc.extra_base,p=e.stat_desc.max_length,m=0;for(s=0;s<=g;s++)t.bl_count[s]=0;for(h[2*t.heap[t.heap_max]+1]=0,r=t.heap_max+1;r<_;r++)p<(s=h[2*h[2*(i=t.heap[r])+1]+1]+1)&&(s=p,m++),h[2*i+1]=s,u<i||(t.bl_count[s]++,a=0,c<=i&&(a=d[i-c]),o=h[2*i],t.opt_len+=o*(s+a),f&&(t.static_len+=o*(l[2*i+1]+a)));if(0!==m){do{for(s=p-1;0===t.bl_count[s];)s--;t.bl_count[s]--,t.bl_count[s+1]+=2,t.bl_count[p]--,m-=2}while(0<m);for(s=p;0!==s;s--)for(i=t.bl_count[s];0!==i;)u<(n=t.heap[--r])||(h[2*n+1]!==s&&(t.opt_len+=(s-h[2*n+1])*h[2*n],h[2*n+1]=s),i--)}}(t,e),Z(s,u,t.bl_count)}function X(t,e,r){var i,n,s=-1,a=e[1],o=0,h=7,u=4;for(0===a&&(h=138,u=3),e[2*(r+1)+1]=65535,i=0;i<=r;i++)n=a,a=e[2*(i+1)+1],++o<h&&n===a||(o<u?t.bl_tree[2*n]+=o:0!==n?(n!==s&&t.bl_tree[2*n]++,t.bl_tree[2*b]++):o<=10?t.bl_tree[2*v]++:t.bl_tree[2*y]++,s=n,u=(o=0)===a?(h=138,3):n===a?(h=6,3):(h=7,4))}function V(t,e,r){var i,n,s=-1,a=e[1],o=0,h=7,u=4;for(0===a&&(h=138,u=3),i=0;i<=r;i++)if(n=a,a=e[2*(i+1)+1],!(++o<h&&n===a)){if(o<u)for(;L(t,n,t.bl_tree),0!=--o;);else 0!==n?(n!==s&&(L(t,n,t.bl_tree),o--),L(t,b,t.bl_tree),P(t,o-3,2)):o<=10?(L(t,v,t.bl_tree),P(t,o-3,3)):(L(t,y,t.bl_tree),P(t,o-11,7));s=n,u=(o=0)===a?(h=138,3):n===a?(h=6,3):(h=7,4)}}i(T);var q=!1;function J(t,e,r,i){P(t,(s<<1)+(i?1:0),3),function(t,e,r,i){M(t),i&&(U(t,r),U(t,~r)),n.arraySet(t.pending_buf,t.window,e,r,t.pending),t.pending+=r}(t,e,r,!0)}r._tr_init=function(t){q||(function(){var t,e,r,i,n,s=new Array(g+1);for(i=r=0;i<a-1;i++)for(I[i]=r,t=0;t<1<<w[i];t++)A[r++]=i;for(A[r-1]=i,i=n=0;i<16;i++)for(T[i]=n,t=0;t<1<<k[i];t++)E[n++]=i;for(n>>=7;i<f;i++)for(T[i]=n<<7,t=0;t<1<<k[i]-7;t++)E[256+n++]=i;for(e=0;e<=g;e++)s[e]=0;for(t=0;t<=143;)z[2*t+1]=8,t++,s[8]++;for(;t<=255;)z[2*t+1]=9,t++,s[9]++;for(;t<=279;)z[2*t+1]=7,t++,s[7]++;for(;t<=287;)z[2*t+1]=8,t++,s[8]++;for(Z(z,l+1,s),t=0;t<f;t++)C[2*t+1]=5,C[2*t]=j(t,5);O=new D(z,w,u+1,l,g),B=new D(C,k,0,f,g),R=new D(new Array(0),x,0,d,p)}(),q=!0),t.l_desc=new F(t.dyn_ltree,O),t.d_desc=new F(t.dyn_dtree,B),t.bl_desc=new F(t.bl_tree,R),t.bi_buf=0,t.bi_valid=0,W(t)},r._tr_stored_block=J,r._tr_flush_block=function(t,e,r,i){var n,s,a=0;0<t.level?(2===t.strm.data_type&&(t.strm.data_type=function(t){var e,r=4093624447;for(e=0;e<=31;e++,r>>>=1)if(1&r&&0!==t.dyn_ltree[2*e])return o;if(0!==t.dyn_ltree[18]||0!==t.dyn_ltree[20]||0!==t.dyn_ltree[26])return h;for(e=32;e<u;e++)if(0!==t.dyn_ltree[2*e])return h;return o}(t)),Y(t,t.l_desc),Y(t,t.d_desc),a=function(t){var e;for(X(t,t.dyn_ltree,t.l_desc.max_code),X(t,t.dyn_dtree,t.d_desc.max_code),Y(t,t.bl_desc),e=d-1;3<=e&&0===t.bl_tree[2*S[e]+1];e--);return t.opt_len+=3*(e+1)+5+5+4,e}(t),n=t.opt_len+3+7>>>3,(s=t.static_len+3+7>>>3)<=n&&(n=s)):n=s=r+5,r+4<=n&&-1!==e?J(t,e,r,i):4===t.strategy||s===n?(P(t,2+(i?1:0),3),K(t,z,C)):(P(t,4+(i?1:0),3),function(t,e,r,i){var n;for(P(t,e-257,5),P(t,r-1,5),P(t,i-4,4),n=0;n<i;n++)P(t,t.bl_tree[2*S[n]+1],3);V(t,t.dyn_ltree,e-1),V(t,t.dyn_dtree,r-1)}(t,t.l_desc.max_code+1,t.d_desc.max_code+1,a+1),K(t,t.dyn_ltree,t.dyn_dtree)),W(t),i&&M(t)},r._tr_tally=function(t,e,r){return t.pending_buf[t.d_buf+2*t.last_lit]=e>>>8&255,t.pending_buf[t.d_buf+2*t.last_lit+1]=255&e,t.pending_buf[t.l_buf+t.last_lit]=255&r,t.last_lit++,0===e?t.dyn_ltree[2*r]++:(t.matches++,e--,t.dyn_ltree[2*(A[r]+u+1)]++,t.dyn_dtree[2*N(e)]++),t.last_lit===t.lit_bufsize-1},r._tr_align=function(t){P(t,2,3),L(t,m,z),function(t){16===t.bi_valid?(U(t,t.bi_buf),t.bi_buf=0,t.bi_valid=0):8<=t.bi_valid&&(t.pending_buf[t.pending++]=255&t.bi_buf,t.bi_buf>>=8,t.bi_valid-=8)}(t)}},{"../utils/common":41}],53:[function(t,e,r){"use strict";e.exports=function(){this.input=null,this.next_in=0,this.avail_in=0,this.total_in=0,this.output=null,this.next_out=0,this.avail_out=0,this.total_out=0,this.msg="",this.state=null,this.data_type=2,this.adler=0}},{}],54:[function(t,e,r){"use strict";e.exports="function"==typeof setImmediate?setImmediate:function(){var t=[].slice.apply(arguments);t.splice(1,0,0),setTimeout.apply(null,t)}},{}]},{},[10])(10)});
+!function(e){if(true)module.exports=e();else // removed by dead control flow
+{}}(function(){return function s(a,o,h){function u(r,e){if(!o[r]){if(!a[r]){var t=undefined;if(!e&&t)return require(r,!0);if(l)return l(r,!0);var n=new Error("Cannot find module '"+r+"'");throw n.code="MODULE_NOT_FOUND",n}var i=o[r]={exports:{}};a[r][0].call(i.exports,function(e){var t=a[r][1][e];return u(t||e)},i,i.exports,s,a,o,h)}return o[r].exports}for(var l=undefined,e=0;e<h.length;e++)u(h[e]);return u}({1:[function(e,t,r){"use strict";var d=e("./utils"),c=e("./support"),p="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";r.encode=function(e){for(var t,r,n,i,s,a,o,h=[],u=0,l=e.length,f=l,c="string"!==d.getTypeOf(e);u<e.length;)f=l-u,n=c?(t=e[u++],r=u<l?e[u++]:0,u<l?e[u++]:0):(t=e.charCodeAt(u++),r=u<l?e.charCodeAt(u++):0,u<l?e.charCodeAt(u++):0),i=t>>2,s=(3&t)<<4|r>>4,a=1<f?(15&r)<<2|n>>6:64,o=2<f?63&n:64,h.push(p.charAt(i)+p.charAt(s)+p.charAt(a)+p.charAt(o));return h.join("")},r.decode=function(e){var t,r,n,i,s,a,o=0,h=0,u="data:";if(e.substr(0,u.length)===u)throw new Error("Invalid base64 input, it looks like a data url.");var l,f=3*(e=e.replace(/[^A-Za-z0-9+/=]/g,"")).length/4;if(e.charAt(e.length-1)===p.charAt(64)&&f--,e.charAt(e.length-2)===p.charAt(64)&&f--,f%1!=0)throw new Error("Invalid base64 input, bad content length.");for(l=c.uint8array?new Uint8Array(0|f):new Array(0|f);o<e.length;)t=p.indexOf(e.charAt(o++))<<2|(i=p.indexOf(e.charAt(o++)))>>4,r=(15&i)<<4|(s=p.indexOf(e.charAt(o++)))>>2,n=(3&s)<<6|(a=p.indexOf(e.charAt(o++))),l[h++]=t,64!==s&&(l[h++]=r),64!==a&&(l[h++]=n);return l}},{"./support":30,"./utils":32}],2:[function(e,t,r){"use strict";var n=e("./external"),i=e("./stream/DataWorker"),s=e("./stream/Crc32Probe"),a=e("./stream/DataLengthProbe");function o(e,t,r,n,i){this.compressedSize=e,this.uncompressedSize=t,this.crc32=r,this.compression=n,this.compressedContent=i}o.prototype={getContentWorker:function(){var e=new i(n.Promise.resolve(this.compressedContent)).pipe(this.compression.uncompressWorker()).pipe(new a("data_length")),t=this;return e.on("end",function(){if(this.streamInfo.data_length!==t.uncompressedSize)throw new Error("Bug : uncompressed data size mismatch")}),e},getCompressedWorker:function(){return new i(n.Promise.resolve(this.compressedContent)).withStreamInfo("compressedSize",this.compressedSize).withStreamInfo("uncompressedSize",this.uncompressedSize).withStreamInfo("crc32",this.crc32).withStreamInfo("compression",this.compression)}},o.createWorkerFrom=function(e,t,r){return e.pipe(new s).pipe(new a("uncompressedSize")).pipe(t.compressWorker(r)).pipe(new a("compressedSize")).withStreamInfo("compression",t)},t.exports=o},{"./external":6,"./stream/Crc32Probe":25,"./stream/DataLengthProbe":26,"./stream/DataWorker":27}],3:[function(e,t,r){"use strict";var n=e("./stream/GenericWorker");r.STORE={magic:"\0\0",compressWorker:function(){return new n("STORE compression")},uncompressWorker:function(){return new n("STORE decompression")}},r.DEFLATE=e("./flate")},{"./flate":7,"./stream/GenericWorker":28}],4:[function(e,t,r){"use strict";var n=e("./utils");var o=function(){for(var e,t=[],r=0;r<256;r++){e=r;for(var n=0;n<8;n++)e=1&e?3988292384^e>>>1:e>>>1;t[r]=e}return t}();t.exports=function(e,t){return void 0!==e&&e.length?"string"!==n.getTypeOf(e)?function(e,t,r,n){var i=o,s=n+r;e^=-1;for(var a=n;a<s;a++)e=e>>>8^i[255&(e^t[a])];return-1^e}(0|t,e,e.length,0):function(e,t,r,n){var i=o,s=n+r;e^=-1;for(var a=n;a<s;a++)e=e>>>8^i[255&(e^t.charCodeAt(a))];return-1^e}(0|t,e,e.length,0):0}},{"./utils":32}],5:[function(e,t,r){"use strict";r.base64=!1,r.binary=!1,r.dir=!1,r.createFolders=!0,r.date=null,r.compression=null,r.compressionOptions=null,r.comment=null,r.unixPermissions=null,r.dosPermissions=null},{}],6:[function(e,t,r){"use strict";var n=null;n="undefined"!=typeof Promise?Promise:e("lie"),t.exports={Promise:n}},{lie:37}],7:[function(e,t,r){"use strict";var n="undefined"!=typeof Uint8Array&&"undefined"!=typeof Uint16Array&&"undefined"!=typeof Uint32Array,i=e("pako"),s=e("./utils"),a=e("./stream/GenericWorker"),o=n?"uint8array":"array";function h(e,t){a.call(this,"FlateWorker/"+e),this._pako=null,this._pakoAction=e,this._pakoOptions=t,this.meta={}}r.magic="\b\0",s.inherits(h,a),h.prototype.processChunk=function(e){this.meta=e.meta,null===this._pako&&this._createPako(),this._pako.push(s.transformTo(o,e.data),!1)},h.prototype.flush=function(){a.prototype.flush.call(this),null===this._pako&&this._createPako(),this._pako.push([],!0)},h.prototype.cleanUp=function(){a.prototype.cleanUp.call(this),this._pako=null},h.prototype._createPako=function(){this._pako=new i[this._pakoAction]({raw:!0,level:this._pakoOptions.level||-1});var t=this;this._pako.onData=function(e){t.push({data:e,meta:t.meta})}},r.compressWorker=function(e){return new h("Deflate",e)},r.uncompressWorker=function(){return new h("Inflate",{})}},{"./stream/GenericWorker":28,"./utils":32,pako:38}],8:[function(e,t,r){"use strict";function A(e,t){var r,n="";for(r=0;r<t;r++)n+=String.fromCharCode(255&e),e>>>=8;return n}function n(e,t,r,n,i,s){var a,o,h=e.file,u=e.compression,l=s!==O.utf8encode,f=I.transformTo("string",s(h.name)),c=I.transformTo("string",O.utf8encode(h.name)),d=h.comment,p=I.transformTo("string",s(d)),m=I.transformTo("string",O.utf8encode(d)),_=c.length!==h.name.length,g=m.length!==d.length,b="",v="",y="",w=h.dir,k=h.date,x={crc32:0,compressedSize:0,uncompressedSize:0};t&&!r||(x.crc32=e.crc32,x.compressedSize=e.compressedSize,x.uncompressedSize=e.uncompressedSize);var S=0;t&&(S|=8),l||!_&&!g||(S|=2048);var z=0,C=0;w&&(z|=16),"UNIX"===i?(C=798,z|=function(e,t){var r=e;return e||(r=t?16893:33204),(65535&r)<<16}(h.unixPermissions,w)):(C=20,z|=function(e){return 63&(e||0)}(h.dosPermissions)),a=k.getUTCHours(),a<<=6,a|=k.getUTCMinutes(),a<<=5,a|=k.getUTCSeconds()/2,o=k.getUTCFullYear()-1980,o<<=4,o|=k.getUTCMonth()+1,o<<=5,o|=k.getUTCDate(),_&&(v=A(1,1)+A(B(f),4)+c,b+="up"+A(v.length,2)+v),g&&(y=A(1,1)+A(B(p),4)+m,b+="uc"+A(y.length,2)+y);var E="";return E+="\n\0",E+=A(S,2),E+=u.magic,E+=A(a,2),E+=A(o,2),E+=A(x.crc32,4),E+=A(x.compressedSize,4),E+=A(x.uncompressedSize,4),E+=A(f.length,2),E+=A(b.length,2),{fileRecord:R.LOCAL_FILE_HEADER+E+f+b,dirRecord:R.CENTRAL_FILE_HEADER+A(C,2)+E+A(p.length,2)+"\0\0\0\0"+A(z,4)+A(n,4)+f+b+p}}var I=e("../utils"),i=e("../stream/GenericWorker"),O=e("../utf8"),B=e("../crc32"),R=e("../signature");function s(e,t,r,n){i.call(this,"ZipFileWorker"),this.bytesWritten=0,this.zipComment=t,this.zipPlatform=r,this.encodeFileName=n,this.streamFiles=e,this.accumulate=!1,this.contentBuffer=[],this.dirRecords=[],this.currentSourceOffset=0,this.entriesCount=0,this.currentFile=null,this._sources=[]}I.inherits(s,i),s.prototype.push=function(e){var t=e.meta.percent||0,r=this.entriesCount,n=this._sources.length;this.accumulate?this.contentBuffer.push(e):(this.bytesWritten+=e.data.length,i.prototype.push.call(this,{data:e.data,meta:{currentFile:this.currentFile,percent:r?(t+100*(r-n-1))/r:100}}))},s.prototype.openedSource=function(e){this.currentSourceOffset=this.bytesWritten,this.currentFile=e.file.name;var t=this.streamFiles&&!e.file.dir;if(t){var r=n(e,t,!1,this.currentSourceOffset,this.zipPlatform,this.encodeFileName);this.push({data:r.fileRecord,meta:{percent:0}})}else this.accumulate=!0},s.prototype.closedSource=function(e){this.accumulate=!1;var t=this.streamFiles&&!e.file.dir,r=n(e,t,!0,this.currentSourceOffset,this.zipPlatform,this.encodeFileName);if(this.dirRecords.push(r.dirRecord),t)this.push({data:function(e){return R.DATA_DESCRIPTOR+A(e.crc32,4)+A(e.compressedSize,4)+A(e.uncompressedSize,4)}(e),meta:{percent:100}});else for(this.push({data:r.fileRecord,meta:{percent:0}});this.contentBuffer.length;)this.push(this.contentBuffer.shift());this.currentFile=null},s.prototype.flush=function(){for(var e=this.bytesWritten,t=0;t<this.dirRecords.length;t++)this.push({data:this.dirRecords[t],meta:{percent:100}});var r=this.bytesWritten-e,n=function(e,t,r,n,i){var s=I.transformTo("string",i(n));return R.CENTRAL_DIRECTORY_END+"\0\0\0\0"+A(e,2)+A(e,2)+A(t,4)+A(r,4)+A(s.length,2)+s}(this.dirRecords.length,r,e,this.zipComment,this.encodeFileName);this.push({data:n,meta:{percent:100}})},s.prototype.prepareNextSource=function(){this.previous=this._sources.shift(),this.openedSource(this.previous.streamInfo),this.isPaused?this.previous.pause():this.previous.resume()},s.prototype.registerPrevious=function(e){this._sources.push(e);var t=this;return e.on("data",function(e){t.processChunk(e)}),e.on("end",function(){t.closedSource(t.previous.streamInfo),t._sources.length?t.prepareNextSource():t.end()}),e.on("error",function(e){t.error(e)}),this},s.prototype.resume=function(){return!!i.prototype.resume.call(this)&&(!this.previous&&this._sources.length?(this.prepareNextSource(),!0):this.previous||this._sources.length||this.generatedError?void 0:(this.end(),!0))},s.prototype.error=function(e){var t=this._sources;if(!i.prototype.error.call(this,e))return!1;for(var r=0;r<t.length;r++)try{t[r].error(e)}catch(e){}return!0},s.prototype.lock=function(){i.prototype.lock.call(this);for(var e=this._sources,t=0;t<e.length;t++)e[t].lock()},t.exports=s},{"../crc32":4,"../signature":23,"../stream/GenericWorker":28,"../utf8":31,"../utils":32}],9:[function(e,t,r){"use strict";var u=e("../compressions"),n=e("./ZipFileWorker");r.generateWorker=function(e,a,t){var o=new n(a.streamFiles,t,a.platform,a.encodeFileName),h=0;try{e.forEach(function(e,t){h++;var r=function(e,t){var r=e||t,n=u[r];if(!n)throw new Error(r+" is not a valid compression method !");return n}(t.options.compression,a.compression),n=t.options.compressionOptions||a.compressionOptions||{},i=t.dir,s=t.date;t._compressWorker(r,n).withStreamInfo("file",{name:e,dir:i,date:s,comment:t.comment||"",unixPermissions:t.unixPermissions,dosPermissions:t.dosPermissions}).pipe(o)}),o.entriesCount=h}catch(e){o.error(e)}return o}},{"../compressions":3,"./ZipFileWorker":8}],10:[function(e,t,r){"use strict";function n(){if(!(this instanceof n))return new n;if(arguments.length)throw new Error("The constructor with parameters has been removed in JSZip 3.0, please check the upgrade guide.");this.files=Object.create(null),this.comment=null,this.root="",this.clone=function(){var e=new n;for(var t in this)"function"!=typeof this[t]&&(e[t]=this[t]);return e}}(n.prototype=e("./object")).loadAsync=e("./load"),n.support=e("./support"),n.defaults=e("./defaults"),n.version="3.10.1",n.loadAsync=function(e,t){return(new n).loadAsync(e,t)},n.external=e("./external"),t.exports=n},{"./defaults":5,"./external":6,"./load":11,"./object":15,"./support":30}],11:[function(e,t,r){"use strict";var u=e("./utils"),i=e("./external"),n=e("./utf8"),s=e("./zipEntries"),a=e("./stream/Crc32Probe"),l=e("./nodejsUtils");function f(n){return new i.Promise(function(e,t){var r=n.decompressed.getContentWorker().pipe(new a);r.on("error",function(e){t(e)}).on("end",function(){r.streamInfo.crc32!==n.decompressed.crc32?t(new Error("Corrupted zip : CRC32 mismatch")):e()}).resume()})}t.exports=function(e,o){var h=this;return o=u.extend(o||{},{base64:!1,checkCRC32:!1,optimizedBinaryString:!1,createFolders:!1,decodeFileName:n.utf8decode}),l.isNode&&l.isStream(e)?i.Promise.reject(new Error("JSZip can't accept a stream when loading a zip file.")):u.prepareContent("the loaded zip file",e,!0,o.optimizedBinaryString,o.base64).then(function(e){var t=new s(o);return t.load(e),t}).then(function(e){var t=[i.Promise.resolve(e)],r=e.files;if(o.checkCRC32)for(var n=0;n<r.length;n++)t.push(f(r[n]));return i.Promise.all(t)}).then(function(e){for(var t=e.shift(),r=t.files,n=0;n<r.length;n++){var i=r[n],s=i.fileNameStr,a=u.resolve(i.fileNameStr);h.file(a,i.decompressed,{binary:!0,optimizedBinaryString:!0,date:i.date,dir:i.dir,comment:i.fileCommentStr.length?i.fileCommentStr:null,unixPermissions:i.unixPermissions,dosPermissions:i.dosPermissions,createFolders:o.createFolders}),i.dir||(h.file(a).unsafeOriginalName=s)}return t.zipComment.length&&(h.comment=t.zipComment),h})}},{"./external":6,"./nodejsUtils":14,"./stream/Crc32Probe":25,"./utf8":31,"./utils":32,"./zipEntries":33}],12:[function(e,t,r){"use strict";var n=e("../utils"),i=e("../stream/GenericWorker");function s(e,t){i.call(this,"Nodejs stream input adapter for "+e),this._upstreamEnded=!1,this._bindStream(t)}n.inherits(s,i),s.prototype._bindStream=function(e){var t=this;(this._stream=e).pause(),e.on("data",function(e){t.push({data:e,meta:{percent:0}})}).on("error",function(e){t.isPaused?this.generatedError=e:t.error(e)}).on("end",function(){t.isPaused?t._upstreamEnded=!0:t.end()})},s.prototype.pause=function(){return!!i.prototype.pause.call(this)&&(this._stream.pause(),!0)},s.prototype.resume=function(){return!!i.prototype.resume.call(this)&&(this._upstreamEnded?this.end():this._stream.resume(),!0)},t.exports=s},{"../stream/GenericWorker":28,"../utils":32}],13:[function(e,t,r){"use strict";var i=e("readable-stream").Readable;function n(e,t,r){i.call(this,t),this._helper=e;var n=this;e.on("data",function(e,t){n.push(e)||n._helper.pause(),r&&r(t)}).on("error",function(e){n.emit("error",e)}).on("end",function(){n.push(null)})}e("../utils").inherits(n,i),n.prototype._read=function(){this._helper.resume()},t.exports=n},{"../utils":32,"readable-stream":16}],14:[function(e,t,r){"use strict";t.exports={isNode:"undefined"!=typeof Buffer,newBufferFrom:function(e,t){if(Buffer.from&&Buffer.from!==Uint8Array.from)return Buffer.from(e,t);if("number"==typeof e)throw new Error('The "data" argument must not be a number');return new Buffer(e,t)},allocBuffer:function(e){if(Buffer.alloc)return Buffer.alloc(e);var t=new Buffer(e);return t.fill(0),t},isBuffer:function(e){return Buffer.isBuffer(e)},isStream:function(e){return e&&"function"==typeof e.on&&"function"==typeof e.pause&&"function"==typeof e.resume}}},{}],15:[function(e,t,r){"use strict";function s(e,t,r){var n,i=u.getTypeOf(t),s=u.extend(r||{},f);s.date=s.date||new Date,null!==s.compression&&(s.compression=s.compression.toUpperCase()),"string"==typeof s.unixPermissions&&(s.unixPermissions=parseInt(s.unixPermissions,8)),s.unixPermissions&&16384&s.unixPermissions&&(s.dir=!0),s.dosPermissions&&16&s.dosPermissions&&(s.dir=!0),s.dir&&(e=g(e)),s.createFolders&&(n=_(e))&&b.call(this,n,!0);var a="string"===i&&!1===s.binary&&!1===s.base64;r&&void 0!==r.binary||(s.binary=!a),(t instanceof c&&0===t.uncompressedSize||s.dir||!t||0===t.length)&&(s.base64=!1,s.binary=!0,t="",s.compression="STORE",i="string");var o=null;o=t instanceof c||t instanceof l?t:p.isNode&&p.isStream(t)?new m(e,t):u.prepareContent(e,t,s.binary,s.optimizedBinaryString,s.base64);var h=new d(e,o,s);this.files[e]=h}var i=e("./utf8"),u=e("./utils"),l=e("./stream/GenericWorker"),a=e("./stream/StreamHelper"),f=e("./defaults"),c=e("./compressedObject"),d=e("./zipObject"),o=e("./generate"),p=e("./nodejsUtils"),m=e("./nodejs/NodejsStreamInputAdapter"),_=function(e){"/"===e.slice(-1)&&(e=e.substring(0,e.length-1));var t=e.lastIndexOf("/");return 0<t?e.substring(0,t):""},g=function(e){return"/"!==e.slice(-1)&&(e+="/"),e},b=function(e,t){return t=void 0!==t?t:f.createFolders,e=g(e),this.files[e]||s.call(this,e,null,{dir:!0,createFolders:t}),this.files[e]};function h(e){return"[object RegExp]"===Object.prototype.toString.call(e)}var n={load:function(){throw new Error("This method has been removed in JSZip 3.0, please check the upgrade guide.")},forEach:function(e){var t,r,n;for(t in this.files)n=this.files[t],(r=t.slice(this.root.length,t.length))&&t.slice(0,this.root.length)===this.root&&e(r,n)},filter:function(r){var n=[];return this.forEach(function(e,t){r(e,t)&&n.push(t)}),n},file:function(e,t,r){if(1!==arguments.length)return e=this.root+e,s.call(this,e,t,r),this;if(h(e)){var n=e;return this.filter(function(e,t){return!t.dir&&n.test(e)})}var i=this.files[this.root+e];return i&&!i.dir?i:null},folder:function(r){if(!r)return this;if(h(r))return this.filter(function(e,t){return t.dir&&r.test(e)});var e=this.root+r,t=b.call(this,e),n=this.clone();return n.root=t.name,n},remove:function(r){r=this.root+r;var e=this.files[r];if(e||("/"!==r.slice(-1)&&(r+="/"),e=this.files[r]),e&&!e.dir)delete this.files[r];else for(var t=this.filter(function(e,t){return t.name.slice(0,r.length)===r}),n=0;n<t.length;n++)delete this.files[t[n].name];return this},generate:function(){throw new Error("This method has been removed in JSZip 3.0, please check the upgrade guide.")},generateInternalStream:function(e){var t,r={};try{if((r=u.extend(e||{},{streamFiles:!1,compression:"STORE",compressionOptions:null,type:"",platform:"DOS",comment:null,mimeType:"application/zip",encodeFileName:i.utf8encode})).type=r.type.toLowerCase(),r.compression=r.compression.toUpperCase(),"binarystring"===r.type&&(r.type="string"),!r.type)throw new Error("No output type specified.");u.checkSupport(r.type),"darwin"!==r.platform&&"freebsd"!==r.platform&&"linux"!==r.platform&&"sunos"!==r.platform||(r.platform="UNIX"),"win32"===r.platform&&(r.platform="DOS");var n=r.comment||this.comment||"";t=o.generateWorker(this,r,n)}catch(e){(t=new l("error")).error(e)}return new a(t,r.type||"string",r.mimeType)},generateAsync:function(e,t){return this.generateInternalStream(e).accumulate(t)},generateNodeStream:function(e,t){return(e=e||{}).type||(e.type="nodebuffer"),this.generateInternalStream(e).toNodejsStream(t)}};t.exports=n},{"./compressedObject":2,"./defaults":5,"./generate":9,"./nodejs/NodejsStreamInputAdapter":12,"./nodejsUtils":14,"./stream/GenericWorker":28,"./stream/StreamHelper":29,"./utf8":31,"./utils":32,"./zipObject":35}],16:[function(e,t,r){"use strict";t.exports=e("stream")},{stream:void 0}],17:[function(e,t,r){"use strict";var n=e("./DataReader");function i(e){n.call(this,e);for(var t=0;t<this.data.length;t++)e[t]=255&e[t]}e("../utils").inherits(i,n),i.prototype.byteAt=function(e){return this.data[this.zero+e]},i.prototype.lastIndexOfSignature=function(e){for(var t=e.charCodeAt(0),r=e.charCodeAt(1),n=e.charCodeAt(2),i=e.charCodeAt(3),s=this.length-4;0<=s;--s)if(this.data[s]===t&&this.data[s+1]===r&&this.data[s+2]===n&&this.data[s+3]===i)return s-this.zero;return-1},i.prototype.readAndCheckSignature=function(e){var t=e.charCodeAt(0),r=e.charCodeAt(1),n=e.charCodeAt(2),i=e.charCodeAt(3),s=this.readData(4);return t===s[0]&&r===s[1]&&n===s[2]&&i===s[3]},i.prototype.readData=function(e){if(this.checkOffset(e),0===e)return[];var t=this.data.slice(this.zero+this.index,this.zero+this.index+e);return this.index+=e,t},t.exports=i},{"../utils":32,"./DataReader":18}],18:[function(e,t,r){"use strict";var n=e("../utils");function i(e){this.data=e,this.length=e.length,this.index=0,this.zero=0}i.prototype={checkOffset:function(e){this.checkIndex(this.index+e)},checkIndex:function(e){if(this.length<this.zero+e||e<0)throw new Error("End of data reached (data length = "+this.length+", asked index = "+e+"). Corrupted zip ?")},setIndex:function(e){this.checkIndex(e),this.index=e},skip:function(e){this.setIndex(this.index+e)},byteAt:function(){},readInt:function(e){var t,r=0;for(this.checkOffset(e),t=this.index+e-1;t>=this.index;t--)r=(r<<8)+this.byteAt(t);return this.index+=e,r},readString:function(e){return n.transformTo("string",this.readData(e))},readData:function(){},lastIndexOfSignature:function(){},readAndCheckSignature:function(){},readDate:function(){var e=this.readInt(4);return new Date(Date.UTC(1980+(e>>25&127),(e>>21&15)-1,e>>16&31,e>>11&31,e>>5&63,(31&e)<<1))}},t.exports=i},{"../utils":32}],19:[function(e,t,r){"use strict";var n=e("./Uint8ArrayReader");function i(e){n.call(this,e)}e("../utils").inherits(i,n),i.prototype.readData=function(e){this.checkOffset(e);var t=this.data.slice(this.zero+this.index,this.zero+this.index+e);return this.index+=e,t},t.exports=i},{"../utils":32,"./Uint8ArrayReader":21}],20:[function(e,t,r){"use strict";var n=e("./DataReader");function i(e){n.call(this,e)}e("../utils").inherits(i,n),i.prototype.byteAt=function(e){return this.data.charCodeAt(this.zero+e)},i.prototype.lastIndexOfSignature=function(e){return this.data.lastIndexOf(e)-this.zero},i.prototype.readAndCheckSignature=function(e){return e===this.readData(4)},i.prototype.readData=function(e){this.checkOffset(e);var t=this.data.slice(this.zero+this.index,this.zero+this.index+e);return this.index+=e,t},t.exports=i},{"../utils":32,"./DataReader":18}],21:[function(e,t,r){"use strict";var n=e("./ArrayReader");function i(e){n.call(this,e)}e("../utils").inherits(i,n),i.prototype.readData=function(e){if(this.checkOffset(e),0===e)return new Uint8Array(0);var t=this.data.subarray(this.zero+this.index,this.zero+this.index+e);return this.index+=e,t},t.exports=i},{"../utils":32,"./ArrayReader":17}],22:[function(e,t,r){"use strict";var n=e("../utils"),i=e("../support"),s=e("./ArrayReader"),a=e("./StringReader"),o=e("./NodeBufferReader"),h=e("./Uint8ArrayReader");t.exports=function(e){var t=n.getTypeOf(e);return n.checkSupport(t),"string"!==t||i.uint8array?"nodebuffer"===t?new o(e):i.uint8array?new h(n.transformTo("uint8array",e)):new s(n.transformTo("array",e)):new a(e)}},{"../support":30,"../utils":32,"./ArrayReader":17,"./NodeBufferReader":19,"./StringReader":20,"./Uint8ArrayReader":21}],23:[function(e,t,r){"use strict";r.LOCAL_FILE_HEADER="PK",r.CENTRAL_FILE_HEADER="PK",r.CENTRAL_DIRECTORY_END="PK",r.ZIP64_CENTRAL_DIRECTORY_LOCATOR="PK",r.ZIP64_CENTRAL_DIRECTORY_END="PK",r.DATA_DESCRIPTOR="PK\b"},{}],24:[function(e,t,r){"use strict";var n=e("./GenericWorker"),i=e("../utils");function s(e){n.call(this,"ConvertWorker to "+e),this.destType=e}i.inherits(s,n),s.prototype.processChunk=function(e){this.push({data:i.transformTo(this.destType,e.data),meta:e.meta})},t.exports=s},{"../utils":32,"./GenericWorker":28}],25:[function(e,t,r){"use strict";var n=e("./GenericWorker"),i=e("../crc32");function s(){n.call(this,"Crc32Probe"),this.withStreamInfo("crc32",0)}e("../utils").inherits(s,n),s.prototype.processChunk=function(e){this.streamInfo.crc32=i(e.data,this.streamInfo.crc32||0),this.push(e)},t.exports=s},{"../crc32":4,"../utils":32,"./GenericWorker":28}],26:[function(e,t,r){"use strict";var n=e("../utils"),i=e("./GenericWorker");function s(e){i.call(this,"DataLengthProbe for "+e),this.propName=e,this.withStreamInfo(e,0)}n.inherits(s,i),s.prototype.processChunk=function(e){if(e){var t=this.streamInfo[this.propName]||0;this.streamInfo[this.propName]=t+e.data.length}i.prototype.processChunk.call(this,e)},t.exports=s},{"../utils":32,"./GenericWorker":28}],27:[function(e,t,r){"use strict";var n=e("../utils"),i=e("./GenericWorker");function s(e){i.call(this,"DataWorker");var t=this;this.dataIsReady=!1,this.index=0,this.max=0,this.data=null,this.type="",this._tickScheduled=!1,e.then(function(e){t.dataIsReady=!0,t.data=e,t.max=e&&e.length||0,t.type=n.getTypeOf(e),t.isPaused||t._tickAndRepeat()},function(e){t.error(e)})}n.inherits(s,i),s.prototype.cleanUp=function(){i.prototype.cleanUp.call(this),this.data=null},s.prototype.resume=function(){return!!i.prototype.resume.call(this)&&(!this._tickScheduled&&this.dataIsReady&&(this._tickScheduled=!0,n.delay(this._tickAndRepeat,[],this)),!0)},s.prototype._tickAndRepeat=function(){this._tickScheduled=!1,this.isPaused||this.isFinished||(this._tick(),this.isFinished||(n.delay(this._tickAndRepeat,[],this),this._tickScheduled=!0))},s.prototype._tick=function(){if(this.isPaused||this.isFinished)return!1;var e=null,t=Math.min(this.max,this.index+16384);if(this.index>=this.max)return this.end();switch(this.type){case"string":e=this.data.substring(this.index,t);break;case"uint8array":e=this.data.subarray(this.index,t);break;case"array":case"nodebuffer":e=this.data.slice(this.index,t)}return this.index=t,this.push({data:e,meta:{percent:this.max?this.index/this.max*100:0}})},t.exports=s},{"../utils":32,"./GenericWorker":28}],28:[function(e,t,r){"use strict";function n(e){this.name=e||"default",this.streamInfo={},this.generatedError=null,this.extraStreamInfo={},this.isPaused=!0,this.isFinished=!1,this.isLocked=!1,this._listeners={data:[],end:[],error:[]},this.previous=null}n.prototype={push:function(e){this.emit("data",e)},end:function(){if(this.isFinished)return!1;this.flush();try{this.emit("end"),this.cleanUp(),this.isFinished=!0}catch(e){this.emit("error",e)}return!0},error:function(e){return!this.isFinished&&(this.isPaused?this.generatedError=e:(this.isFinished=!0,this.emit("error",e),this.previous&&this.previous.error(e),this.cleanUp()),!0)},on:function(e,t){return this._listeners[e].push(t),this},cleanUp:function(){this.streamInfo=this.generatedError=this.extraStreamInfo=null,this._listeners=[]},emit:function(e,t){if(this._listeners[e])for(var r=0;r<this._listeners[e].length;r++)this._listeners[e][r].call(this,t)},pipe:function(e){return e.registerPrevious(this)},registerPrevious:function(e){if(this.isLocked)throw new Error("The stream '"+this+"' has already been used.");this.streamInfo=e.streamInfo,this.mergeStreamInfo(),this.previous=e;var t=this;return e.on("data",function(e){t.processChunk(e)}),e.on("end",function(){t.end()}),e.on("error",function(e){t.error(e)}),this},pause:function(){return!this.isPaused&&!this.isFinished&&(this.isPaused=!0,this.previous&&this.previous.pause(),!0)},resume:function(){if(!this.isPaused||this.isFinished)return!1;var e=this.isPaused=!1;return this.generatedError&&(this.error(this.generatedError),e=!0),this.previous&&this.previous.resume(),!e},flush:function(){},processChunk:function(e){this.push(e)},withStreamInfo:function(e,t){return this.extraStreamInfo[e]=t,this.mergeStreamInfo(),this},mergeStreamInfo:function(){for(var e in this.extraStreamInfo)Object.prototype.hasOwnProperty.call(this.extraStreamInfo,e)&&(this.streamInfo[e]=this.extraStreamInfo[e])},lock:function(){if(this.isLocked)throw new Error("The stream '"+this+"' has already been used.");this.isLocked=!0,this.previous&&this.previous.lock()},toString:function(){var e="Worker "+this.name;return this.previous?this.previous+" -> "+e:e}},t.exports=n},{}],29:[function(e,t,r){"use strict";var h=e("../utils"),i=e("./ConvertWorker"),s=e("./GenericWorker"),u=e("../base64"),n=e("../support"),a=e("../external"),o=null;if(n.nodestream)try{o=e("../nodejs/NodejsStreamOutputAdapter")}catch(e){}function l(e,o){return new a.Promise(function(t,r){var n=[],i=e._internalType,s=e._outputType,a=e._mimeType;e.on("data",function(e,t){n.push(e),o&&o(t)}).on("error",function(e){n=[],r(e)}).on("end",function(){try{var e=function(e,t,r){switch(e){case"blob":return h.newBlob(h.transformTo("arraybuffer",t),r);case"base64":return u.encode(t);default:return h.transformTo(e,t)}}(s,function(e,t){var r,n=0,i=null,s=0;for(r=0;r<t.length;r++)s+=t[r].length;switch(e){case"string":return t.join("");case"array":return Array.prototype.concat.apply([],t);case"uint8array":for(i=new Uint8Array(s),r=0;r<t.length;r++)i.set(t[r],n),n+=t[r].length;return i;case"nodebuffer":return Buffer.concat(t);default:throw new Error("concat : unsupported type '"+e+"'")}}(i,n),a);t(e)}catch(e){r(e)}n=[]}).resume()})}function f(e,t,r){var n=t;switch(t){case"blob":case"arraybuffer":n="uint8array";break;case"base64":n="string"}try{this._internalType=n,this._outputType=t,this._mimeType=r,h.checkSupport(n),this._worker=e.pipe(new i(n)),e.lock()}catch(e){this._worker=new s("error"),this._worker.error(e)}}f.prototype={accumulate:function(e){return l(this,e)},on:function(e,t){var r=this;return"data"===e?this._worker.on(e,function(e){t.call(r,e.data,e.meta)}):this._worker.on(e,function(){h.delay(t,arguments,r)}),this},resume:function(){return h.delay(this._worker.resume,[],this._worker),this},pause:function(){return this._worker.pause(),this},toNodejsStream:function(e){if(h.checkSupport("nodestream"),"nodebuffer"!==this._outputType)throw new Error(this._outputType+" is not supported by this method");return new o(this,{objectMode:"nodebuffer"!==this._outputType},e)}},t.exports=f},{"../base64":1,"../external":6,"../nodejs/NodejsStreamOutputAdapter":13,"../support":30,"../utils":32,"./ConvertWorker":24,"./GenericWorker":28}],30:[function(e,t,r){"use strict";if(r.base64=!0,r.array=!0,r.string=!0,r.arraybuffer="undefined"!=typeof ArrayBuffer&&"undefined"!=typeof Uint8Array,r.nodebuffer="undefined"!=typeof Buffer,r.uint8array="undefined"!=typeof Uint8Array,"undefined"==typeof ArrayBuffer)r.blob=!1;else{var n=new ArrayBuffer(0);try{r.blob=0===new Blob([n],{type:"application/zip"}).size}catch(e){try{var i=new(self.BlobBuilder||self.WebKitBlobBuilder||self.MozBlobBuilder||self.MSBlobBuilder);i.append(n),r.blob=0===i.getBlob("application/zip").size}catch(e){r.blob=!1}}}try{r.nodestream=!!e("readable-stream").Readable}catch(e){r.nodestream=!1}},{"readable-stream":16}],31:[function(e,t,s){"use strict";for(var o=e("./utils"),h=e("./support"),r=e("./nodejsUtils"),n=e("./stream/GenericWorker"),u=new Array(256),i=0;i<256;i++)u[i]=252<=i?6:248<=i?5:240<=i?4:224<=i?3:192<=i?2:1;u[254]=u[254]=1;function a(){n.call(this,"utf-8 decode"),this.leftOver=null}function l(){n.call(this,"utf-8 encode")}s.utf8encode=function(e){return h.nodebuffer?r.newBufferFrom(e,"utf-8"):function(e){var t,r,n,i,s,a=e.length,o=0;for(i=0;i<a;i++)55296==(64512&(r=e.charCodeAt(i)))&&i+1<a&&56320==(64512&(n=e.charCodeAt(i+1)))&&(r=65536+(r-55296<<10)+(n-56320),i++),o+=r<128?1:r<2048?2:r<65536?3:4;for(t=h.uint8array?new Uint8Array(o):new Array(o),i=s=0;s<o;i++)55296==(64512&(r=e.charCodeAt(i)))&&i+1<a&&56320==(64512&(n=e.charCodeAt(i+1)))&&(r=65536+(r-55296<<10)+(n-56320),i++),r<128?t[s++]=r:(r<2048?t[s++]=192|r>>>6:(r<65536?t[s++]=224|r>>>12:(t[s++]=240|r>>>18,t[s++]=128|r>>>12&63),t[s++]=128|r>>>6&63),t[s++]=128|63&r);return t}(e)},s.utf8decode=function(e){return h.nodebuffer?o.transformTo("nodebuffer",e).toString("utf-8"):function(e){var t,r,n,i,s=e.length,a=new Array(2*s);for(t=r=0;t<s;)if((n=e[t++])<128)a[r++]=n;else if(4<(i=u[n]))a[r++]=65533,t+=i-1;else{for(n&=2===i?31:3===i?15:7;1<i&&t<s;)n=n<<6|63&e[t++],i--;1<i?a[r++]=65533:n<65536?a[r++]=n:(n-=65536,a[r++]=55296|n>>10&1023,a[r++]=56320|1023&n)}return a.length!==r&&(a.subarray?a=a.subarray(0,r):a.length=r),o.applyFromCharCode(a)}(e=o.transformTo(h.uint8array?"uint8array":"array",e))},o.inherits(a,n),a.prototype.processChunk=function(e){var t=o.transformTo(h.uint8array?"uint8array":"array",e.data);if(this.leftOver&&this.leftOver.length){if(h.uint8array){var r=t;(t=new Uint8Array(r.length+this.leftOver.length)).set(this.leftOver,0),t.set(r,this.leftOver.length)}else t=this.leftOver.concat(t);this.leftOver=null}var n=function(e,t){var r;for((t=t||e.length)>e.length&&(t=e.length),r=t-1;0<=r&&128==(192&e[r]);)r--;return r<0?t:0===r?t:r+u[e[r]]>t?r:t}(t),i=t;n!==t.length&&(h.uint8array?(i=t.subarray(0,n),this.leftOver=t.subarray(n,t.length)):(i=t.slice(0,n),this.leftOver=t.slice(n,t.length))),this.push({data:s.utf8decode(i),meta:e.meta})},a.prototype.flush=function(){this.leftOver&&this.leftOver.length&&(this.push({data:s.utf8decode(this.leftOver),meta:{}}),this.leftOver=null)},s.Utf8DecodeWorker=a,o.inherits(l,n),l.prototype.processChunk=function(e){this.push({data:s.utf8encode(e.data),meta:e.meta})},s.Utf8EncodeWorker=l},{"./nodejsUtils":14,"./stream/GenericWorker":28,"./support":30,"./utils":32}],32:[function(e,t,a){"use strict";var o=e("./support"),h=e("./base64"),r=e("./nodejsUtils"),u=e("./external");function n(e){return e}function l(e,t){for(var r=0;r<e.length;++r)t[r]=255&e.charCodeAt(r);return t}e("setimmediate"),a.newBlob=function(t,r){a.checkSupport("blob");try{return new Blob([t],{type:r})}catch(e){try{var n=new(self.BlobBuilder||self.WebKitBlobBuilder||self.MozBlobBuilder||self.MSBlobBuilder);return n.append(t),n.getBlob(r)}catch(e){throw new Error("Bug : can't construct the Blob.")}}};var i={stringifyByChunk:function(e,t,r){var n=[],i=0,s=e.length;if(s<=r)return String.fromCharCode.apply(null,e);for(;i<s;)"array"===t||"nodebuffer"===t?n.push(String.fromCharCode.apply(null,e.slice(i,Math.min(i+r,s)))):n.push(String.fromCharCode.apply(null,e.subarray(i,Math.min(i+r,s)))),i+=r;return n.join("")},stringifyByChar:function(e){for(var t="",r=0;r<e.length;r++)t+=String.fromCharCode(e[r]);return t},applyCanBeUsed:{uint8array:function(){try{return o.uint8array&&1===String.fromCharCode.apply(null,new Uint8Array(1)).length}catch(e){return!1}}(),nodebuffer:function(){try{return o.nodebuffer&&1===String.fromCharCode.apply(null,r.allocBuffer(1)).length}catch(e){return!1}}()}};function s(e){var t=65536,r=a.getTypeOf(e),n=!0;if("uint8array"===r?n=i.applyCanBeUsed.uint8array:"nodebuffer"===r&&(n=i.applyCanBeUsed.nodebuffer),n)for(;1<t;)try{return i.stringifyByChunk(e,r,t)}catch(e){t=Math.floor(t/2)}return i.stringifyByChar(e)}function f(e,t){for(var r=0;r<e.length;r++)t[r]=e[r];return t}a.applyFromCharCode=s;var c={};c.string={string:n,array:function(e){return l(e,new Array(e.length))},arraybuffer:function(e){return c.string.uint8array(e).buffer},uint8array:function(e){return l(e,new Uint8Array(e.length))},nodebuffer:function(e){return l(e,r.allocBuffer(e.length))}},c.array={string:s,array:n,arraybuffer:function(e){return new Uint8Array(e).buffer},uint8array:function(e){return new Uint8Array(e)},nodebuffer:function(e){return r.newBufferFrom(e)}},c.arraybuffer={string:function(e){return s(new Uint8Array(e))},array:function(e){return f(new Uint8Array(e),new Array(e.byteLength))},arraybuffer:n,uint8array:function(e){return new Uint8Array(e)},nodebuffer:function(e){return r.newBufferFrom(new Uint8Array(e))}},c.uint8array={string:s,array:function(e){return f(e,new Array(e.length))},arraybuffer:function(e){return e.buffer},uint8array:n,nodebuffer:function(e){return r.newBufferFrom(e)}},c.nodebuffer={string:s,array:function(e){return f(e,new Array(e.length))},arraybuffer:function(e){return c.nodebuffer.uint8array(e).buffer},uint8array:function(e){return f(e,new Uint8Array(e.length))},nodebuffer:n},a.transformTo=function(e,t){if(t=t||"",!e)return t;a.checkSupport(e);var r=a.getTypeOf(t);return c[r][e](t)},a.resolve=function(e){for(var t=e.split("/"),r=[],n=0;n<t.length;n++){var i=t[n];"."===i||""===i&&0!==n&&n!==t.length-1||(".."===i?r.pop():r.push(i))}return r.join("/")},a.getTypeOf=function(e){return"string"==typeof e?"string":"[object Array]"===Object.prototype.toString.call(e)?"array":o.nodebuffer&&r.isBuffer(e)?"nodebuffer":o.uint8array&&e instanceof Uint8Array?"uint8array":o.arraybuffer&&e instanceof ArrayBuffer?"arraybuffer":void 0},a.checkSupport=function(e){if(!o[e.toLowerCase()])throw new Error(e+" is not supported by this platform")},a.MAX_VALUE_16BITS=65535,a.MAX_VALUE_32BITS=-1,a.pretty=function(e){var t,r,n="";for(r=0;r<(e||"").length;r++)n+="\\x"+((t=e.charCodeAt(r))<16?"0":"")+t.toString(16).toUpperCase();return n},a.delay=function(e,t,r){setImmediate(function(){e.apply(r||null,t||[])})},a.inherits=function(e,t){function r(){}r.prototype=t.prototype,e.prototype=new r},a.extend=function(){var e,t,r={};for(e=0;e<arguments.length;e++)for(t in arguments[e])Object.prototype.hasOwnProperty.call(arguments[e],t)&&void 0===r[t]&&(r[t]=arguments[e][t]);return r},a.prepareContent=function(r,e,n,i,s){return u.Promise.resolve(e).then(function(n){return o.blob&&(n instanceof Blob||-1!==["[object File]","[object Blob]"].indexOf(Object.prototype.toString.call(n)))&&"undefined"!=typeof FileReader?new u.Promise(function(t,r){var e=new FileReader;e.onload=function(e){t(e.target.result)},e.onerror=function(e){r(e.target.error)},e.readAsArrayBuffer(n)}):n}).then(function(e){var t=a.getTypeOf(e);return t?("arraybuffer"===t?e=a.transformTo("uint8array",e):"string"===t&&(s?e=h.decode(e):n&&!0!==i&&(e=function(e){return l(e,o.uint8array?new Uint8Array(e.length):new Array(e.length))}(e))),e):u.Promise.reject(new Error("Can't read the data of '"+r+"'. Is it in a supported JavaScript type (String, Blob, ArrayBuffer, etc) ?"))})}},{"./base64":1,"./external":6,"./nodejsUtils":14,"./support":30,setimmediate:54}],33:[function(e,t,r){"use strict";var n=e("./reader/readerFor"),i=e("./utils"),s=e("./signature"),a=e("./zipEntry"),o=e("./support");function h(e){this.files=[],this.loadOptions=e}h.prototype={checkSignature:function(e){if(!this.reader.readAndCheckSignature(e)){this.reader.index-=4;var t=this.reader.readString(4);throw new Error("Corrupted zip or bug: unexpected signature ("+i.pretty(t)+", expected "+i.pretty(e)+")")}},isSignature:function(e,t){var r=this.reader.index;this.reader.setIndex(e);var n=this.reader.readString(4)===t;return this.reader.setIndex(r),n},readBlockEndOfCentral:function(){this.diskNumber=this.reader.readInt(2),this.diskWithCentralDirStart=this.reader.readInt(2),this.centralDirRecordsOnThisDisk=this.reader.readInt(2),this.centralDirRecords=this.reader.readInt(2),this.centralDirSize=this.reader.readInt(4),this.centralDirOffset=this.reader.readInt(4),this.zipCommentLength=this.reader.readInt(2);var e=this.reader.readData(this.zipCommentLength),t=o.uint8array?"uint8array":"array",r=i.transformTo(t,e);this.zipComment=this.loadOptions.decodeFileName(r)},readBlockZip64EndOfCentral:function(){this.zip64EndOfCentralSize=this.reader.readInt(8),this.reader.skip(4),this.diskNumber=this.reader.readInt(4),this.diskWithCentralDirStart=this.reader.readInt(4),this.centralDirRecordsOnThisDisk=this.reader.readInt(8),this.centralDirRecords=this.reader.readInt(8),this.centralDirSize=this.reader.readInt(8),this.centralDirOffset=this.reader.readInt(8),this.zip64ExtensibleData={};for(var e,t,r,n=this.zip64EndOfCentralSize-44;0<n;)e=this.reader.readInt(2),t=this.reader.readInt(4),r=this.reader.readData(t),this.zip64ExtensibleData[e]={id:e,length:t,value:r}},readBlockZip64EndOfCentralLocator:function(){if(this.diskWithZip64CentralDirStart=this.reader.readInt(4),this.relativeOffsetEndOfZip64CentralDir=this.reader.readInt(8),this.disksCount=this.reader.readInt(4),1<this.disksCount)throw new Error("Multi-volumes zip are not supported")},readLocalFiles:function(){var e,t;for(e=0;e<this.files.length;e++)t=this.files[e],this.reader.setIndex(t.localHeaderOffset),this.checkSignature(s.LOCAL_FILE_HEADER),t.readLocalPart(this.reader),t.handleUTF8(),t.processAttributes()},readCentralDir:function(){var e;for(this.reader.setIndex(this.centralDirOffset);this.reader.readAndCheckSignature(s.CENTRAL_FILE_HEADER);)(e=new a({zip64:this.zip64},this.loadOptions)).readCentralPart(this.reader),this.files.push(e);if(this.centralDirRecords!==this.files.length&&0!==this.centralDirRecords&&0===this.files.length)throw new Error("Corrupted zip or bug: expected "+this.centralDirRecords+" records in central dir, got "+this.files.length)},readEndOfCentral:function(){var e=this.reader.lastIndexOfSignature(s.CENTRAL_DIRECTORY_END);if(e<0)throw!this.isSignature(0,s.LOCAL_FILE_HEADER)?new Error("Can't find end of central directory : is this a zip file ? If it is, see https://stuk.github.io/jszip/documentation/howto/read_zip.html"):new Error("Corrupted zip: can't find end of central directory");this.reader.setIndex(e);var t=e;if(this.checkSignature(s.CENTRAL_DIRECTORY_END),this.readBlockEndOfCentral(),this.diskNumber===i.MAX_VALUE_16BITS||this.diskWithCentralDirStart===i.MAX_VALUE_16BITS||this.centralDirRecordsOnThisDisk===i.MAX_VALUE_16BITS||this.centralDirRecords===i.MAX_VALUE_16BITS||this.centralDirSize===i.MAX_VALUE_32BITS||this.centralDirOffset===i.MAX_VALUE_32BITS){if(this.zip64=!0,(e=this.reader.lastIndexOfSignature(s.ZIP64_CENTRAL_DIRECTORY_LOCATOR))<0)throw new Error("Corrupted zip: can't find the ZIP64 end of central directory locator");if(this.reader.setIndex(e),this.checkSignature(s.ZIP64_CENTRAL_DIRECTORY_LOCATOR),this.readBlockZip64EndOfCentralLocator(),!this.isSignature(this.relativeOffsetEndOfZip64CentralDir,s.ZIP64_CENTRAL_DIRECTORY_END)&&(this.relativeOffsetEndOfZip64CentralDir=this.reader.lastIndexOfSignature(s.ZIP64_CENTRAL_DIRECTORY_END),this.relativeOffsetEndOfZip64CentralDir<0))throw new Error("Corrupted zip: can't find the ZIP64 end of central directory");this.reader.setIndex(this.relativeOffsetEndOfZip64CentralDir),this.checkSignature(s.ZIP64_CENTRAL_DIRECTORY_END),this.readBlockZip64EndOfCentral()}var r=this.centralDirOffset+this.centralDirSize;this.zip64&&(r+=20,r+=12+this.zip64EndOfCentralSize);var n=t-r;if(0<n)this.isSignature(t,s.CENTRAL_FILE_HEADER)||(this.reader.zero=n);else if(n<0)throw new Error("Corrupted zip: missing "+Math.abs(n)+" bytes.")},prepareReader:function(e){this.reader=n(e)},load:function(e){this.prepareReader(e),this.readEndOfCentral(),this.readCentralDir(),this.readLocalFiles()}},t.exports=h},{"./reader/readerFor":22,"./signature":23,"./support":30,"./utils":32,"./zipEntry":34}],34:[function(e,t,r){"use strict";var n=e("./reader/readerFor"),s=e("./utils"),i=e("./compressedObject"),a=e("./crc32"),o=e("./utf8"),h=e("./compressions"),u=e("./support");function l(e,t){this.options=e,this.loadOptions=t}l.prototype={isEncrypted:function(){return 1==(1&this.bitFlag)},useUTF8:function(){return 2048==(2048&this.bitFlag)},readLocalPart:function(e){var t,r;if(e.skip(22),this.fileNameLength=e.readInt(2),r=e.readInt(2),this.fileName=e.readData(this.fileNameLength),e.skip(r),-1===this.compressedSize||-1===this.uncompressedSize)throw new Error("Bug or corrupted zip : didn't get enough information from the central directory (compressedSize === -1 || uncompressedSize === -1)");if(null===(t=function(e){for(var t in h)if(Object.prototype.hasOwnProperty.call(h,t)&&h[t].magic===e)return h[t];return null}(this.compressionMethod)))throw new Error("Corrupted zip : compression "+s.pretty(this.compressionMethod)+" unknown (inner file : "+s.transformTo("string",this.fileName)+")");this.decompressed=new i(this.compressedSize,this.uncompressedSize,this.crc32,t,e.readData(this.compressedSize))},readCentralPart:function(e){this.versionMadeBy=e.readInt(2),e.skip(2),this.bitFlag=e.readInt(2),this.compressionMethod=e.readString(2),this.date=e.readDate(),this.crc32=e.readInt(4),this.compressedSize=e.readInt(4),this.uncompressedSize=e.readInt(4);var t=e.readInt(2);if(this.extraFieldsLength=e.readInt(2),this.fileCommentLength=e.readInt(2),this.diskNumberStart=e.readInt(2),this.internalFileAttributes=e.readInt(2),this.externalFileAttributes=e.readInt(4),this.localHeaderOffset=e.readInt(4),this.isEncrypted())throw new Error("Encrypted zip are not supported");e.skip(t),this.readExtraFields(e),this.parseZIP64ExtraField(e),this.fileComment=e.readData(this.fileCommentLength)},processAttributes:function(){this.unixPermissions=null,this.dosPermissions=null;var e=this.versionMadeBy>>8;this.dir=!!(16&this.externalFileAttributes),0==e&&(this.dosPermissions=63&this.externalFileAttributes),3==e&&(this.unixPermissions=this.externalFileAttributes>>16&65535),this.dir||"/"!==this.fileNameStr.slice(-1)||(this.dir=!0)},parseZIP64ExtraField:function(){if(this.extraFields[1]){var e=n(this.extraFields[1].value);this.uncompressedSize===s.MAX_VALUE_32BITS&&(this.uncompressedSize=e.readInt(8)),this.compressedSize===s.MAX_VALUE_32BITS&&(this.compressedSize=e.readInt(8)),this.localHeaderOffset===s.MAX_VALUE_32BITS&&(this.localHeaderOffset=e.readInt(8)),this.diskNumberStart===s.MAX_VALUE_32BITS&&(this.diskNumberStart=e.readInt(4))}},readExtraFields:function(e){var t,r,n,i=e.index+this.extraFieldsLength;for(this.extraFields||(this.extraFields={});e.index+4<i;)t=e.readInt(2),r=e.readInt(2),n=e.readData(r),this.extraFields[t]={id:t,length:r,value:n};e.setIndex(i)},handleUTF8:function(){var e=u.uint8array?"uint8array":"array";if(this.useUTF8())this.fileNameStr=o.utf8decode(this.fileName),this.fileCommentStr=o.utf8decode(this.fileComment);else{var t=this.findExtraFieldUnicodePath();if(null!==t)this.fileNameStr=t;else{var r=s.transformTo(e,this.fileName);this.fileNameStr=this.loadOptions.decodeFileName(r)}var n=this.findExtraFieldUnicodeComment();if(null!==n)this.fileCommentStr=n;else{var i=s.transformTo(e,this.fileComment);this.fileCommentStr=this.loadOptions.decodeFileName(i)}}},findExtraFieldUnicodePath:function(){var e=this.extraFields[28789];if(e){var t=n(e.value);return 1!==t.readInt(1)?null:a(this.fileName)!==t.readInt(4)?null:o.utf8decode(t.readData(e.length-5))}return null},findExtraFieldUnicodeComment:function(){var e=this.extraFields[25461];if(e){var t=n(e.value);return 1!==t.readInt(1)?null:a(this.fileComment)!==t.readInt(4)?null:o.utf8decode(t.readData(e.length-5))}return null}},t.exports=l},{"./compressedObject":2,"./compressions":3,"./crc32":4,"./reader/readerFor":22,"./support":30,"./utf8":31,"./utils":32}],35:[function(e,t,r){"use strict";function n(e,t,r){this.name=e,this.dir=r.dir,this.date=r.date,this.comment=r.comment,this.unixPermissions=r.unixPermissions,this.dosPermissions=r.dosPermissions,this._data=t,this._dataBinary=r.binary,this.options={compression:r.compression,compressionOptions:r.compressionOptions}}var s=e("./stream/StreamHelper"),i=e("./stream/DataWorker"),a=e("./utf8"),o=e("./compressedObject"),h=e("./stream/GenericWorker");n.prototype={internalStream:function(e){var t=null,r="string";try{if(!e)throw new Error("No output type specified.");var n="string"===(r=e.toLowerCase())||"text"===r;"binarystring"!==r&&"text"!==r||(r="string"),t=this._decompressWorker();var i=!this._dataBinary;i&&!n&&(t=t.pipe(new a.Utf8EncodeWorker)),!i&&n&&(t=t.pipe(new a.Utf8DecodeWorker))}catch(e){(t=new h("error")).error(e)}return new s(t,r,"")},async:function(e,t){return this.internalStream(e).accumulate(t)},nodeStream:function(e,t){return this.internalStream(e||"nodebuffer").toNodejsStream(t)},_compressWorker:function(e,t){if(this._data instanceof o&&this._data.compression.magic===e.magic)return this._data.getCompressedWorker();var r=this._decompressWorker();return this._dataBinary||(r=r.pipe(new a.Utf8EncodeWorker)),o.createWorkerFrom(r,e,t)},_decompressWorker:function(){return this._data instanceof o?this._data.getContentWorker():this._data instanceof h?this._data:new i(this._data)}};for(var u=["asText","asBinary","asNodeBuffer","asUint8Array","asArrayBuffer"],l=function(){throw new Error("This method has been removed in JSZip 3.0, please check the upgrade guide.")},f=0;f<u.length;f++)n.prototype[u[f]]=l;t.exports=n},{"./compressedObject":2,"./stream/DataWorker":27,"./stream/GenericWorker":28,"./stream/StreamHelper":29,"./utf8":31}],36:[function(e,l,t){(function(t){"use strict";var r,n,e=t.MutationObserver||t.WebKitMutationObserver;if(e){var i=0,s=new e(u),a=t.document.createTextNode("");s.observe(a,{characterData:!0}),r=function(){a.data=i=++i%2}}else if(t.setImmediate||void 0===t.MessageChannel)r="document"in t&&"onreadystatechange"in t.document.createElement("script")?function(){var e=t.document.createElement("script");e.onreadystatechange=function(){u(),e.onreadystatechange=null,e.parentNode.removeChild(e),e=null},t.document.documentElement.appendChild(e)}:function(){setTimeout(u,0)};else{var o=new t.MessageChannel;o.port1.onmessage=u,r=function(){o.port2.postMessage(0)}}var h=[];function u(){var e,t;n=!0;for(var r=h.length;r;){for(t=h,h=[],e=-1;++e<r;)t[e]();r=h.length}n=!1}l.exports=function(e){1!==h.push(e)||n||r()}}).call(this,"undefined"!=typeof __webpack_require__.g?__webpack_require__.g:"undefined"!=typeof self?self:"undefined"!=typeof window?window:{})},{}],37:[function(e,t,r){"use strict";var i=e("immediate");function u(){}var l={},s=["REJECTED"],a=["FULFILLED"],n=["PENDING"];function o(e){if("function"!=typeof e)throw new TypeError("resolver must be a function");this.state=n,this.queue=[],this.outcome=void 0,e!==u&&d(this,e)}function h(e,t,r){this.promise=e,"function"==typeof t&&(this.onFulfilled=t,this.callFulfilled=this.otherCallFulfilled),"function"==typeof r&&(this.onRejected=r,this.callRejected=this.otherCallRejected)}function f(t,r,n){i(function(){var e;try{e=r(n)}catch(e){return l.reject(t,e)}e===t?l.reject(t,new TypeError("Cannot resolve promise with itself")):l.resolve(t,e)})}function c(e){var t=e&&e.then;if(e&&("object"==typeof e||"function"==typeof e)&&"function"==typeof t)return function(){t.apply(e,arguments)}}function d(t,e){var r=!1;function n(e){r||(r=!0,l.reject(t,e))}function i(e){r||(r=!0,l.resolve(t,e))}var s=p(function(){e(i,n)});"error"===s.status&&n(s.value)}function p(e,t){var r={};try{r.value=e(t),r.status="success"}catch(e){r.status="error",r.value=e}return r}(t.exports=o).prototype.finally=function(t){if("function"!=typeof t)return this;var r=this.constructor;return this.then(function(e){return r.resolve(t()).then(function(){return e})},function(e){return r.resolve(t()).then(function(){throw e})})},o.prototype.catch=function(e){return this.then(null,e)},o.prototype.then=function(e,t){if("function"!=typeof e&&this.state===a||"function"!=typeof t&&this.state===s)return this;var r=new this.constructor(u);this.state!==n?f(r,this.state===a?e:t,this.outcome):this.queue.push(new h(r,e,t));return r},h.prototype.callFulfilled=function(e){l.resolve(this.promise,e)},h.prototype.otherCallFulfilled=function(e){f(this.promise,this.onFulfilled,e)},h.prototype.callRejected=function(e){l.reject(this.promise,e)},h.prototype.otherCallRejected=function(e){f(this.promise,this.onRejected,e)},l.resolve=function(e,t){var r=p(c,t);if("error"===r.status)return l.reject(e,r.value);var n=r.value;if(n)d(e,n);else{e.state=a,e.outcome=t;for(var i=-1,s=e.queue.length;++i<s;)e.queue[i].callFulfilled(t)}return e},l.reject=function(e,t){e.state=s,e.outcome=t;for(var r=-1,n=e.queue.length;++r<n;)e.queue[r].callRejected(t);return e},o.resolve=function(e){if(e instanceof this)return e;return l.resolve(new this(u),e)},o.reject=function(e){var t=new this(u);return l.reject(t,e)},o.all=function(e){var r=this;if("[object Array]"!==Object.prototype.toString.call(e))return this.reject(new TypeError("must be an array"));var n=e.length,i=!1;if(!n)return this.resolve([]);var s=new Array(n),a=0,t=-1,o=new this(u);for(;++t<n;)h(e[t],t);return o;function h(e,t){r.resolve(e).then(function(e){s[t]=e,++a!==n||i||(i=!0,l.resolve(o,s))},function(e){i||(i=!0,l.reject(o,e))})}},o.race=function(e){var t=this;if("[object Array]"!==Object.prototype.toString.call(e))return this.reject(new TypeError("must be an array"));var r=e.length,n=!1;if(!r)return this.resolve([]);var i=-1,s=new this(u);for(;++i<r;)a=e[i],t.resolve(a).then(function(e){n||(n=!0,l.resolve(s,e))},function(e){n||(n=!0,l.reject(s,e))});var a;return s}},{immediate:36}],38:[function(e,t,r){"use strict";var n={};(0,e("./lib/utils/common").assign)(n,e("./lib/deflate"),e("./lib/inflate"),e("./lib/zlib/constants")),t.exports=n},{"./lib/deflate":39,"./lib/inflate":40,"./lib/utils/common":41,"./lib/zlib/constants":44}],39:[function(e,t,r){"use strict";var a=e("./zlib/deflate"),o=e("./utils/common"),h=e("./utils/strings"),i=e("./zlib/messages"),s=e("./zlib/zstream"),u=Object.prototype.toString,l=0,f=-1,c=0,d=8;function p(e){if(!(this instanceof p))return new p(e);this.options=o.assign({level:f,method:d,chunkSize:16384,windowBits:15,memLevel:8,strategy:c,to:""},e||{});var t=this.options;t.raw&&0<t.windowBits?t.windowBits=-t.windowBits:t.gzip&&0<t.windowBits&&t.windowBits<16&&(t.windowBits+=16),this.err=0,this.msg="",this.ended=!1,this.chunks=[],this.strm=new s,this.strm.avail_out=0;var r=a.deflateInit2(this.strm,t.level,t.method,t.windowBits,t.memLevel,t.strategy);if(r!==l)throw new Error(i[r]);if(t.header&&a.deflateSetHeader(this.strm,t.header),t.dictionary){var n;if(n="string"==typeof t.dictionary?h.string2buf(t.dictionary):"[object ArrayBuffer]"===u.call(t.dictionary)?new Uint8Array(t.dictionary):t.dictionary,(r=a.deflateSetDictionary(this.strm,n))!==l)throw new Error(i[r]);this._dict_set=!0}}function n(e,t){var r=new p(t);if(r.push(e,!0),r.err)throw r.msg||i[r.err];return r.result}p.prototype.push=function(e,t){var r,n,i=this.strm,s=this.options.chunkSize;if(this.ended)return!1;n=t===~~t?t:!0===t?4:0,"string"==typeof e?i.input=h.string2buf(e):"[object ArrayBuffer]"===u.call(e)?i.input=new Uint8Array(e):i.input=e,i.next_in=0,i.avail_in=i.input.length;do{if(0===i.avail_out&&(i.output=new o.Buf8(s),i.next_out=0,i.avail_out=s),1!==(r=a.deflate(i,n))&&r!==l)return this.onEnd(r),!(this.ended=!0);0!==i.avail_out&&(0!==i.avail_in||4!==n&&2!==n)||("string"===this.options.to?this.onData(h.buf2binstring(o.shrinkBuf(i.output,i.next_out))):this.onData(o.shrinkBuf(i.output,i.next_out)))}while((0<i.avail_in||0===i.avail_out)&&1!==r);return 4===n?(r=a.deflateEnd(this.strm),this.onEnd(r),this.ended=!0,r===l):2!==n||(this.onEnd(l),!(i.avail_out=0))},p.prototype.onData=function(e){this.chunks.push(e)},p.prototype.onEnd=function(e){e===l&&("string"===this.options.to?this.result=this.chunks.join(""):this.result=o.flattenChunks(this.chunks)),this.chunks=[],this.err=e,this.msg=this.strm.msg},r.Deflate=p,r.deflate=n,r.deflateRaw=function(e,t){return(t=t||{}).raw=!0,n(e,t)},r.gzip=function(e,t){return(t=t||{}).gzip=!0,n(e,t)}},{"./utils/common":41,"./utils/strings":42,"./zlib/deflate":46,"./zlib/messages":51,"./zlib/zstream":53}],40:[function(e,t,r){"use strict";var c=e("./zlib/inflate"),d=e("./utils/common"),p=e("./utils/strings"),m=e("./zlib/constants"),n=e("./zlib/messages"),i=e("./zlib/zstream"),s=e("./zlib/gzheader"),_=Object.prototype.toString;function a(e){if(!(this instanceof a))return new a(e);this.options=d.assign({chunkSize:16384,windowBits:0,to:""},e||{});var t=this.options;t.raw&&0<=t.windowBits&&t.windowBits<16&&(t.windowBits=-t.windowBits,0===t.windowBits&&(t.windowBits=-15)),!(0<=t.windowBits&&t.windowBits<16)||e&&e.windowBits||(t.windowBits+=32),15<t.windowBits&&t.windowBits<48&&0==(15&t.windowBits)&&(t.windowBits|=15),this.err=0,this.msg="",this.ended=!1,this.chunks=[],this.strm=new i,this.strm.avail_out=0;var r=c.inflateInit2(this.strm,t.windowBits);if(r!==m.Z_OK)throw new Error(n[r]);this.header=new s,c.inflateGetHeader(this.strm,this.header)}function o(e,t){var r=new a(t);if(r.push(e,!0),r.err)throw r.msg||n[r.err];return r.result}a.prototype.push=function(e,t){var r,n,i,s,a,o,h=this.strm,u=this.options.chunkSize,l=this.options.dictionary,f=!1;if(this.ended)return!1;n=t===~~t?t:!0===t?m.Z_FINISH:m.Z_NO_FLUSH,"string"==typeof e?h.input=p.binstring2buf(e):"[object ArrayBuffer]"===_.call(e)?h.input=new Uint8Array(e):h.input=e,h.next_in=0,h.avail_in=h.input.length;do{if(0===h.avail_out&&(h.output=new d.Buf8(u),h.next_out=0,h.avail_out=u),(r=c.inflate(h,m.Z_NO_FLUSH))===m.Z_NEED_DICT&&l&&(o="string"==typeof l?p.string2buf(l):"[object ArrayBuffer]"===_.call(l)?new Uint8Array(l):l,r=c.inflateSetDictionary(this.strm,o)),r===m.Z_BUF_ERROR&&!0===f&&(r=m.Z_OK,f=!1),r!==m.Z_STREAM_END&&r!==m.Z_OK)return this.onEnd(r),!(this.ended=!0);h.next_out&&(0!==h.avail_out&&r!==m.Z_STREAM_END&&(0!==h.avail_in||n!==m.Z_FINISH&&n!==m.Z_SYNC_FLUSH)||("string"===this.options.to?(i=p.utf8border(h.output,h.next_out),s=h.next_out-i,a=p.buf2string(h.output,i),h.next_out=s,h.avail_out=u-s,s&&d.arraySet(h.output,h.output,i,s,0),this.onData(a)):this.onData(d.shrinkBuf(h.output,h.next_out)))),0===h.avail_in&&0===h.avail_out&&(f=!0)}while((0<h.avail_in||0===h.avail_out)&&r!==m.Z_STREAM_END);return r===m.Z_STREAM_END&&(n=m.Z_FINISH),n===m.Z_FINISH?(r=c.inflateEnd(this.strm),this.onEnd(r),this.ended=!0,r===m.Z_OK):n!==m.Z_SYNC_FLUSH||(this.onEnd(m.Z_OK),!(h.avail_out=0))},a.prototype.onData=function(e){this.chunks.push(e)},a.prototype.onEnd=function(e){e===m.Z_OK&&("string"===this.options.to?this.result=this.chunks.join(""):this.result=d.flattenChunks(this.chunks)),this.chunks=[],this.err=e,this.msg=this.strm.msg},r.Inflate=a,r.inflate=o,r.inflateRaw=function(e,t){return(t=t||{}).raw=!0,o(e,t)},r.ungzip=o},{"./utils/common":41,"./utils/strings":42,"./zlib/constants":44,"./zlib/gzheader":47,"./zlib/inflate":49,"./zlib/messages":51,"./zlib/zstream":53}],41:[function(e,t,r){"use strict";var n="undefined"!=typeof Uint8Array&&"undefined"!=typeof Uint16Array&&"undefined"!=typeof Int32Array;r.assign=function(e){for(var t=Array.prototype.slice.call(arguments,1);t.length;){var r=t.shift();if(r){if("object"!=typeof r)throw new TypeError(r+"must be non-object");for(var n in r)r.hasOwnProperty(n)&&(e[n]=r[n])}}return e},r.shrinkBuf=function(e,t){return e.length===t?e:e.subarray?e.subarray(0,t):(e.length=t,e)};var i={arraySet:function(e,t,r,n,i){if(t.subarray&&e.subarray)e.set(t.subarray(r,r+n),i);else for(var s=0;s<n;s++)e[i+s]=t[r+s]},flattenChunks:function(e){var t,r,n,i,s,a;for(t=n=0,r=e.length;t<r;t++)n+=e[t].length;for(a=new Uint8Array(n),t=i=0,r=e.length;t<r;t++)s=e[t],a.set(s,i),i+=s.length;return a}},s={arraySet:function(e,t,r,n,i){for(var s=0;s<n;s++)e[i+s]=t[r+s]},flattenChunks:function(e){return[].concat.apply([],e)}};r.setTyped=function(e){e?(r.Buf8=Uint8Array,r.Buf16=Uint16Array,r.Buf32=Int32Array,r.assign(r,i)):(r.Buf8=Array,r.Buf16=Array,r.Buf32=Array,r.assign(r,s))},r.setTyped(n)},{}],42:[function(e,t,r){"use strict";var h=e("./common"),i=!0,s=!0;try{String.fromCharCode.apply(null,[0])}catch(e){i=!1}try{String.fromCharCode.apply(null,new Uint8Array(1))}catch(e){s=!1}for(var u=new h.Buf8(256),n=0;n<256;n++)u[n]=252<=n?6:248<=n?5:240<=n?4:224<=n?3:192<=n?2:1;function l(e,t){if(t<65537&&(e.subarray&&s||!e.subarray&&i))return String.fromCharCode.apply(null,h.shrinkBuf(e,t));for(var r="",n=0;n<t;n++)r+=String.fromCharCode(e[n]);return r}u[254]=u[254]=1,r.string2buf=function(e){var t,r,n,i,s,a=e.length,o=0;for(i=0;i<a;i++)55296==(64512&(r=e.charCodeAt(i)))&&i+1<a&&56320==(64512&(n=e.charCodeAt(i+1)))&&(r=65536+(r-55296<<10)+(n-56320),i++),o+=r<128?1:r<2048?2:r<65536?3:4;for(t=new h.Buf8(o),i=s=0;s<o;i++)55296==(64512&(r=e.charCodeAt(i)))&&i+1<a&&56320==(64512&(n=e.charCodeAt(i+1)))&&(r=65536+(r-55296<<10)+(n-56320),i++),r<128?t[s++]=r:(r<2048?t[s++]=192|r>>>6:(r<65536?t[s++]=224|r>>>12:(t[s++]=240|r>>>18,t[s++]=128|r>>>12&63),t[s++]=128|r>>>6&63),t[s++]=128|63&r);return t},r.buf2binstring=function(e){return l(e,e.length)},r.binstring2buf=function(e){for(var t=new h.Buf8(e.length),r=0,n=t.length;r<n;r++)t[r]=e.charCodeAt(r);return t},r.buf2string=function(e,t){var r,n,i,s,a=t||e.length,o=new Array(2*a);for(r=n=0;r<a;)if((i=e[r++])<128)o[n++]=i;else if(4<(s=u[i]))o[n++]=65533,r+=s-1;else{for(i&=2===s?31:3===s?15:7;1<s&&r<a;)i=i<<6|63&e[r++],s--;1<s?o[n++]=65533:i<65536?o[n++]=i:(i-=65536,o[n++]=55296|i>>10&1023,o[n++]=56320|1023&i)}return l(o,n)},r.utf8border=function(e,t){var r;for((t=t||e.length)>e.length&&(t=e.length),r=t-1;0<=r&&128==(192&e[r]);)r--;return r<0?t:0===r?t:r+u[e[r]]>t?r:t}},{"./common":41}],43:[function(e,t,r){"use strict";t.exports=function(e,t,r,n){for(var i=65535&e|0,s=e>>>16&65535|0,a=0;0!==r;){for(r-=a=2e3<r?2e3:r;s=s+(i=i+t[n++]|0)|0,--a;);i%=65521,s%=65521}return i|s<<16|0}},{}],44:[function(e,t,r){"use strict";t.exports={Z_NO_FLUSH:0,Z_PARTIAL_FLUSH:1,Z_SYNC_FLUSH:2,Z_FULL_FLUSH:3,Z_FINISH:4,Z_BLOCK:5,Z_TREES:6,Z_OK:0,Z_STREAM_END:1,Z_NEED_DICT:2,Z_ERRNO:-1,Z_STREAM_ERROR:-2,Z_DATA_ERROR:-3,Z_BUF_ERROR:-5,Z_NO_COMPRESSION:0,Z_BEST_SPEED:1,Z_BEST_COMPRESSION:9,Z_DEFAULT_COMPRESSION:-1,Z_FILTERED:1,Z_HUFFMAN_ONLY:2,Z_RLE:3,Z_FIXED:4,Z_DEFAULT_STRATEGY:0,Z_BINARY:0,Z_TEXT:1,Z_UNKNOWN:2,Z_DEFLATED:8}},{}],45:[function(e,t,r){"use strict";var o=function(){for(var e,t=[],r=0;r<256;r++){e=r;for(var n=0;n<8;n++)e=1&e?3988292384^e>>>1:e>>>1;t[r]=e}return t}();t.exports=function(e,t,r,n){var i=o,s=n+r;e^=-1;for(var a=n;a<s;a++)e=e>>>8^i[255&(e^t[a])];return-1^e}},{}],46:[function(e,t,r){"use strict";var h,c=e("../utils/common"),u=e("./trees"),d=e("./adler32"),p=e("./crc32"),n=e("./messages"),l=0,f=4,m=0,_=-2,g=-1,b=4,i=2,v=8,y=9,s=286,a=30,o=19,w=2*s+1,k=15,x=3,S=258,z=S+x+1,C=42,E=113,A=1,I=2,O=3,B=4;function R(e,t){return e.msg=n[t],t}function T(e){return(e<<1)-(4<e?9:0)}function D(e){for(var t=e.length;0<=--t;)e[t]=0}function F(e){var t=e.state,r=t.pending;r>e.avail_out&&(r=e.avail_out),0!==r&&(c.arraySet(e.output,t.pending_buf,t.pending_out,r,e.next_out),e.next_out+=r,t.pending_out+=r,e.total_out+=r,e.avail_out-=r,t.pending-=r,0===t.pending&&(t.pending_out=0))}function N(e,t){u._tr_flush_block(e,0<=e.block_start?e.block_start:-1,e.strstart-e.block_start,t),e.block_start=e.strstart,F(e.strm)}function U(e,t){e.pending_buf[e.pending++]=t}function P(e,t){e.pending_buf[e.pending++]=t>>>8&255,e.pending_buf[e.pending++]=255&t}function L(e,t){var r,n,i=e.max_chain_length,s=e.strstart,a=e.prev_length,o=e.nice_match,h=e.strstart>e.w_size-z?e.strstart-(e.w_size-z):0,u=e.window,l=e.w_mask,f=e.prev,c=e.strstart+S,d=u[s+a-1],p=u[s+a];e.prev_length>=e.good_match&&(i>>=2),o>e.lookahead&&(o=e.lookahead);do{if(u[(r=t)+a]===p&&u[r+a-1]===d&&u[r]===u[s]&&u[++r]===u[s+1]){s+=2,r++;do{}while(u[++s]===u[++r]&&u[++s]===u[++r]&&u[++s]===u[++r]&&u[++s]===u[++r]&&u[++s]===u[++r]&&u[++s]===u[++r]&&u[++s]===u[++r]&&u[++s]===u[++r]&&s<c);if(n=S-(c-s),s=c-S,a<n){if(e.match_start=t,o<=(a=n))break;d=u[s+a-1],p=u[s+a]}}}while((t=f[t&l])>h&&0!=--i);return a<=e.lookahead?a:e.lookahead}function j(e){var t,r,n,i,s,a,o,h,u,l,f=e.w_size;do{if(i=e.window_size-e.lookahead-e.strstart,e.strstart>=f+(f-z)){for(c.arraySet(e.window,e.window,f,f,0),e.match_start-=f,e.strstart-=f,e.block_start-=f,t=r=e.hash_size;n=e.head[--t],e.head[t]=f<=n?n-f:0,--r;);for(t=r=f;n=e.prev[--t],e.prev[t]=f<=n?n-f:0,--r;);i+=f}if(0===e.strm.avail_in)break;if(a=e.strm,o=e.window,h=e.strstart+e.lookahead,u=i,l=void 0,l=a.avail_in,u<l&&(l=u),r=0===l?0:(a.avail_in-=l,c.arraySet(o,a.input,a.next_in,l,h),1===a.state.wrap?a.adler=d(a.adler,o,l,h):2===a.state.wrap&&(a.adler=p(a.adler,o,l,h)),a.next_in+=l,a.total_in+=l,l),e.lookahead+=r,e.lookahead+e.insert>=x)for(s=e.strstart-e.insert,e.ins_h=e.window[s],e.ins_h=(e.ins_h<<e.hash_shift^e.window[s+1])&e.hash_mask;e.insert&&(e.ins_h=(e.ins_h<<e.hash_shift^e.window[s+x-1])&e.hash_mask,e.prev[s&e.w_mask]=e.head[e.ins_h],e.head[e.ins_h]=s,s++,e.insert--,!(e.lookahead+e.insert<x)););}while(e.lookahead<z&&0!==e.strm.avail_in)}function Z(e,t){for(var r,n;;){if(e.lookahead<z){if(j(e),e.lookahead<z&&t===l)return A;if(0===e.lookahead)break}if(r=0,e.lookahead>=x&&(e.ins_h=(e.ins_h<<e.hash_shift^e.window[e.strstart+x-1])&e.hash_mask,r=e.prev[e.strstart&e.w_mask]=e.head[e.ins_h],e.head[e.ins_h]=e.strstart),0!==r&&e.strstart-r<=e.w_size-z&&(e.match_length=L(e,r)),e.match_length>=x)if(n=u._tr_tally(e,e.strstart-e.match_start,e.match_length-x),e.lookahead-=e.match_length,e.match_length<=e.max_lazy_match&&e.lookahead>=x){for(e.match_length--;e.strstart++,e.ins_h=(e.ins_h<<e.hash_shift^e.window[e.strstart+x-1])&e.hash_mask,r=e.prev[e.strstart&e.w_mask]=e.head[e.ins_h],e.head[e.ins_h]=e.strstart,0!=--e.match_length;);e.strstart++}else e.strstart+=e.match_length,e.match_length=0,e.ins_h=e.window[e.strstart],e.ins_h=(e.ins_h<<e.hash_shift^e.window[e.strstart+1])&e.hash_mask;else n=u._tr_tally(e,0,e.window[e.strstart]),e.lookahead--,e.strstart++;if(n&&(N(e,!1),0===e.strm.avail_out))return A}return e.insert=e.strstart<x-1?e.strstart:x-1,t===f?(N(e,!0),0===e.strm.avail_out?O:B):e.last_lit&&(N(e,!1),0===e.strm.avail_out)?A:I}function W(e,t){for(var r,n,i;;){if(e.lookahead<z){if(j(e),e.lookahead<z&&t===l)return A;if(0===e.lookahead)break}if(r=0,e.lookahead>=x&&(e.ins_h=(e.ins_h<<e.hash_shift^e.window[e.strstart+x-1])&e.hash_mask,r=e.prev[e.strstart&e.w_mask]=e.head[e.ins_h],e.head[e.ins_h]=e.strstart),e.prev_length=e.match_length,e.prev_match=e.match_start,e.match_length=x-1,0!==r&&e.prev_length<e.max_lazy_match&&e.strstart-r<=e.w_size-z&&(e.match_length=L(e,r),e.match_length<=5&&(1===e.strategy||e.match_length===x&&4096<e.strstart-e.match_start)&&(e.match_length=x-1)),e.prev_length>=x&&e.match_length<=e.prev_length){for(i=e.strstart+e.lookahead-x,n=u._tr_tally(e,e.strstart-1-e.prev_match,e.prev_length-x),e.lookahead-=e.prev_length-1,e.prev_length-=2;++e.strstart<=i&&(e.ins_h=(e.ins_h<<e.hash_shift^e.window[e.strstart+x-1])&e.hash_mask,r=e.prev[e.strstart&e.w_mask]=e.head[e.ins_h],e.head[e.ins_h]=e.strstart),0!=--e.prev_length;);if(e.match_available=0,e.match_length=x-1,e.strstart++,n&&(N(e,!1),0===e.strm.avail_out))return A}else if(e.match_available){if((n=u._tr_tally(e,0,e.window[e.strstart-1]))&&N(e,!1),e.strstart++,e.lookahead--,0===e.strm.avail_out)return A}else e.match_available=1,e.strstart++,e.lookahead--}return e.match_available&&(n=u._tr_tally(e,0,e.window[e.strstart-1]),e.match_available=0),e.insert=e.strstart<x-1?e.strstart:x-1,t===f?(N(e,!0),0===e.strm.avail_out?O:B):e.last_lit&&(N(e,!1),0===e.strm.avail_out)?A:I}function M(e,t,r,n,i){this.good_length=e,this.max_lazy=t,this.nice_length=r,this.max_chain=n,this.func=i}function H(){this.strm=null,this.status=0,this.pending_buf=null,this.pending_buf_size=0,this.pending_out=0,this.pending=0,this.wrap=0,this.gzhead=null,this.gzindex=0,this.method=v,this.last_flush=-1,this.w_size=0,this.w_bits=0,this.w_mask=0,this.window=null,this.window_size=0,this.prev=null,this.head=null,this.ins_h=0,this.hash_size=0,this.hash_bits=0,this.hash_mask=0,this.hash_shift=0,this.block_start=0,this.match_length=0,this.prev_match=0,this.match_available=0,this.strstart=0,this.match_start=0,this.lookahead=0,this.prev_length=0,this.max_chain_length=0,this.max_lazy_match=0,this.level=0,this.strategy=0,this.good_match=0,this.nice_match=0,this.dyn_ltree=new c.Buf16(2*w),this.dyn_dtree=new c.Buf16(2*(2*a+1)),this.bl_tree=new c.Buf16(2*(2*o+1)),D(this.dyn_ltree),D(this.dyn_dtree),D(this.bl_tree),this.l_desc=null,this.d_desc=null,this.bl_desc=null,this.bl_count=new c.Buf16(k+1),this.heap=new c.Buf16(2*s+1),D(this.heap),this.heap_len=0,this.heap_max=0,this.depth=new c.Buf16(2*s+1),D(this.depth),this.l_buf=0,this.lit_bufsize=0,this.last_lit=0,this.d_buf=0,this.opt_len=0,this.static_len=0,this.matches=0,this.insert=0,this.bi_buf=0,this.bi_valid=0}function G(e){var t;return e&&e.state?(e.total_in=e.total_out=0,e.data_type=i,(t=e.state).pending=0,t.pending_out=0,t.wrap<0&&(t.wrap=-t.wrap),t.status=t.wrap?C:E,e.adler=2===t.wrap?0:1,t.last_flush=l,u._tr_init(t),m):R(e,_)}function K(e){var t=G(e);return t===m&&function(e){e.window_size=2*e.w_size,D(e.head),e.max_lazy_match=h[e.level].max_lazy,e.good_match=h[e.level].good_length,e.nice_match=h[e.level].nice_length,e.max_chain_length=h[e.level].max_chain,e.strstart=0,e.block_start=0,e.lookahead=0,e.insert=0,e.match_length=e.prev_length=x-1,e.match_available=0,e.ins_h=0}(e.state),t}function Y(e,t,r,n,i,s){if(!e)return _;var a=1;if(t===g&&(t=6),n<0?(a=0,n=-n):15<n&&(a=2,n-=16),i<1||y<i||r!==v||n<8||15<n||t<0||9<t||s<0||b<s)return R(e,_);8===n&&(n=9);var o=new H;return(e.state=o).strm=e,o.wrap=a,o.gzhead=null,o.w_bits=n,o.w_size=1<<o.w_bits,o.w_mask=o.w_size-1,o.hash_bits=i+7,o.hash_size=1<<o.hash_bits,o.hash_mask=o.hash_size-1,o.hash_shift=~~((o.hash_bits+x-1)/x),o.window=new c.Buf8(2*o.w_size),o.head=new c.Buf16(o.hash_size),o.prev=new c.Buf16(o.w_size),o.lit_bufsize=1<<i+6,o.pending_buf_size=4*o.lit_bufsize,o.pending_buf=new c.Buf8(o.pending_buf_size),o.d_buf=1*o.lit_bufsize,o.l_buf=3*o.lit_bufsize,o.level=t,o.strategy=s,o.method=r,K(e)}h=[new M(0,0,0,0,function(e,t){var r=65535;for(r>e.pending_buf_size-5&&(r=e.pending_buf_size-5);;){if(e.lookahead<=1){if(j(e),0===e.lookahead&&t===l)return A;if(0===e.lookahead)break}e.strstart+=e.lookahead,e.lookahead=0;var n=e.block_start+r;if((0===e.strstart||e.strstart>=n)&&(e.lookahead=e.strstart-n,e.strstart=n,N(e,!1),0===e.strm.avail_out))return A;if(e.strstart-e.block_start>=e.w_size-z&&(N(e,!1),0===e.strm.avail_out))return A}return e.insert=0,t===f?(N(e,!0),0===e.strm.avail_out?O:B):(e.strstart>e.block_start&&(N(e,!1),e.strm.avail_out),A)}),new M(4,4,8,4,Z),new M(4,5,16,8,Z),new M(4,6,32,32,Z),new M(4,4,16,16,W),new M(8,16,32,32,W),new M(8,16,128,128,W),new M(8,32,128,256,W),new M(32,128,258,1024,W),new M(32,258,258,4096,W)],r.deflateInit=function(e,t){return Y(e,t,v,15,8,0)},r.deflateInit2=Y,r.deflateReset=K,r.deflateResetKeep=G,r.deflateSetHeader=function(e,t){return e&&e.state?2!==e.state.wrap?_:(e.state.gzhead=t,m):_},r.deflate=function(e,t){var r,n,i,s;if(!e||!e.state||5<t||t<0)return e?R(e,_):_;if(n=e.state,!e.output||!e.input&&0!==e.avail_in||666===n.status&&t!==f)return R(e,0===e.avail_out?-5:_);if(n.strm=e,r=n.last_flush,n.last_flush=t,n.status===C)if(2===n.wrap)e.adler=0,U(n,31),U(n,139),U(n,8),n.gzhead?(U(n,(n.gzhead.text?1:0)+(n.gzhead.hcrc?2:0)+(n.gzhead.extra?4:0)+(n.gzhead.name?8:0)+(n.gzhead.comment?16:0)),U(n,255&n.gzhead.time),U(n,n.gzhead.time>>8&255),U(n,n.gzhead.time>>16&255),U(n,n.gzhead.time>>24&255),U(n,9===n.level?2:2<=n.strategy||n.level<2?4:0),U(n,255&n.gzhead.os),n.gzhead.extra&&n.gzhead.extra.length&&(U(n,255&n.gzhead.extra.length),U(n,n.gzhead.extra.length>>8&255)),n.gzhead.hcrc&&(e.adler=p(e.adler,n.pending_buf,n.pending,0)),n.gzindex=0,n.status=69):(U(n,0),U(n,0),U(n,0),U(n,0),U(n,0),U(n,9===n.level?2:2<=n.strategy||n.level<2?4:0),U(n,3),n.status=E);else{var a=v+(n.w_bits-8<<4)<<8;a|=(2<=n.strategy||n.level<2?0:n.level<6?1:6===n.level?2:3)<<6,0!==n.strstart&&(a|=32),a+=31-a%31,n.status=E,P(n,a),0!==n.strstart&&(P(n,e.adler>>>16),P(n,65535&e.adler)),e.adler=1}if(69===n.status)if(n.gzhead.extra){for(i=n.pending;n.gzindex<(65535&n.gzhead.extra.length)&&(n.pending!==n.pending_buf_size||(n.gzhead.hcrc&&n.pending>i&&(e.adler=p(e.adler,n.pending_buf,n.pending-i,i)),F(e),i=n.pending,n.pending!==n.pending_buf_size));)U(n,255&n.gzhead.extra[n.gzindex]),n.gzindex++;n.gzhead.hcrc&&n.pending>i&&(e.adler=p(e.adler,n.pending_buf,n.pending-i,i)),n.gzindex===n.gzhead.extra.length&&(n.gzindex=0,n.status=73)}else n.status=73;if(73===n.status)if(n.gzhead.name){i=n.pending;do{if(n.pending===n.pending_buf_size&&(n.gzhead.hcrc&&n.pending>i&&(e.adler=p(e.adler,n.pending_buf,n.pending-i,i)),F(e),i=n.pending,n.pending===n.pending_buf_size)){s=1;break}s=n.gzindex<n.gzhead.name.length?255&n.gzhead.name.charCodeAt(n.gzindex++):0,U(n,s)}while(0!==s);n.gzhead.hcrc&&n.pending>i&&(e.adler=p(e.adler,n.pending_buf,n.pending-i,i)),0===s&&(n.gzindex=0,n.status=91)}else n.status=91;if(91===n.status)if(n.gzhead.comment){i=n.pending;do{if(n.pending===n.pending_buf_size&&(n.gzhead.hcrc&&n.pending>i&&(e.adler=p(e.adler,n.pending_buf,n.pending-i,i)),F(e),i=n.pending,n.pending===n.pending_buf_size)){s=1;break}s=n.gzindex<n.gzhead.comment.length?255&n.gzhead.comment.charCodeAt(n.gzindex++):0,U(n,s)}while(0!==s);n.gzhead.hcrc&&n.pending>i&&(e.adler=p(e.adler,n.pending_buf,n.pending-i,i)),0===s&&(n.status=103)}else n.status=103;if(103===n.status&&(n.gzhead.hcrc?(n.pending+2>n.pending_buf_size&&F(e),n.pending+2<=n.pending_buf_size&&(U(n,255&e.adler),U(n,e.adler>>8&255),e.adler=0,n.status=E)):n.status=E),0!==n.pending){if(F(e),0===e.avail_out)return n.last_flush=-1,m}else if(0===e.avail_in&&T(t)<=T(r)&&t!==f)return R(e,-5);if(666===n.status&&0!==e.avail_in)return R(e,-5);if(0!==e.avail_in||0!==n.lookahead||t!==l&&666!==n.status){var o=2===n.strategy?function(e,t){for(var r;;){if(0===e.lookahead&&(j(e),0===e.lookahead)){if(t===l)return A;break}if(e.match_length=0,r=u._tr_tally(e,0,e.window[e.strstart]),e.lookahead--,e.strstart++,r&&(N(e,!1),0===e.strm.avail_out))return A}return e.insert=0,t===f?(N(e,!0),0===e.strm.avail_out?O:B):e.last_lit&&(N(e,!1),0===e.strm.avail_out)?A:I}(n,t):3===n.strategy?function(e,t){for(var r,n,i,s,a=e.window;;){if(e.lookahead<=S){if(j(e),e.lookahead<=S&&t===l)return A;if(0===e.lookahead)break}if(e.match_length=0,e.lookahead>=x&&0<e.strstart&&(n=a[i=e.strstart-1])===a[++i]&&n===a[++i]&&n===a[++i]){s=e.strstart+S;do{}while(n===a[++i]&&n===a[++i]&&n===a[++i]&&n===a[++i]&&n===a[++i]&&n===a[++i]&&n===a[++i]&&n===a[++i]&&i<s);e.match_length=S-(s-i),e.match_length>e.lookahead&&(e.match_length=e.lookahead)}if(e.match_length>=x?(r=u._tr_tally(e,1,e.match_length-x),e.lookahead-=e.match_length,e.strstart+=e.match_length,e.match_length=0):(r=u._tr_tally(e,0,e.window[e.strstart]),e.lookahead--,e.strstart++),r&&(N(e,!1),0===e.strm.avail_out))return A}return e.insert=0,t===f?(N(e,!0),0===e.strm.avail_out?O:B):e.last_lit&&(N(e,!1),0===e.strm.avail_out)?A:I}(n,t):h[n.level].func(n,t);if(o!==O&&o!==B||(n.status=666),o===A||o===O)return 0===e.avail_out&&(n.last_flush=-1),m;if(o===I&&(1===t?u._tr_align(n):5!==t&&(u._tr_stored_block(n,0,0,!1),3===t&&(D(n.head),0===n.lookahead&&(n.strstart=0,n.block_start=0,n.insert=0))),F(e),0===e.avail_out))return n.last_flush=-1,m}return t!==f?m:n.wrap<=0?1:(2===n.wrap?(U(n,255&e.adler),U(n,e.adler>>8&255),U(n,e.adler>>16&255),U(n,e.adler>>24&255),U(n,255&e.total_in),U(n,e.total_in>>8&255),U(n,e.total_in>>16&255),U(n,e.total_in>>24&255)):(P(n,e.adler>>>16),P(n,65535&e.adler)),F(e),0<n.wrap&&(n.wrap=-n.wrap),0!==n.pending?m:1)},r.deflateEnd=function(e){var t;return e&&e.state?(t=e.state.status)!==C&&69!==t&&73!==t&&91!==t&&103!==t&&t!==E&&666!==t?R(e,_):(e.state=null,t===E?R(e,-3):m):_},r.deflateSetDictionary=function(e,t){var r,n,i,s,a,o,h,u,l=t.length;if(!e||!e.state)return _;if(2===(s=(r=e.state).wrap)||1===s&&r.status!==C||r.lookahead)return _;for(1===s&&(e.adler=d(e.adler,t,l,0)),r.wrap=0,l>=r.w_size&&(0===s&&(D(r.head),r.strstart=0,r.block_start=0,r.insert=0),u=new c.Buf8(r.w_size),c.arraySet(u,t,l-r.w_size,r.w_size,0),t=u,l=r.w_size),a=e.avail_in,o=e.next_in,h=e.input,e.avail_in=l,e.next_in=0,e.input=t,j(r);r.lookahead>=x;){for(n=r.strstart,i=r.lookahead-(x-1);r.ins_h=(r.ins_h<<r.hash_shift^r.window[n+x-1])&r.hash_mask,r.prev[n&r.w_mask]=r.head[r.ins_h],r.head[r.ins_h]=n,n++,--i;);r.strstart=n,r.lookahead=x-1,j(r)}return r.strstart+=r.lookahead,r.block_start=r.strstart,r.insert=r.lookahead,r.lookahead=0,r.match_length=r.prev_length=x-1,r.match_available=0,e.next_in=o,e.input=h,e.avail_in=a,r.wrap=s,m},r.deflateInfo="pako deflate (from Nodeca project)"},{"../utils/common":41,"./adler32":43,"./crc32":45,"./messages":51,"./trees":52}],47:[function(e,t,r){"use strict";t.exports=function(){this.text=0,this.time=0,this.xflags=0,this.os=0,this.extra=null,this.extra_len=0,this.name="",this.comment="",this.hcrc=0,this.done=!1}},{}],48:[function(e,t,r){"use strict";t.exports=function(e,t){var r,n,i,s,a,o,h,u,l,f,c,d,p,m,_,g,b,v,y,w,k,x,S,z,C;r=e.state,n=e.next_in,z=e.input,i=n+(e.avail_in-5),s=e.next_out,C=e.output,a=s-(t-e.avail_out),o=s+(e.avail_out-257),h=r.dmax,u=r.wsize,l=r.whave,f=r.wnext,c=r.window,d=r.hold,p=r.bits,m=r.lencode,_=r.distcode,g=(1<<r.lenbits)-1,b=(1<<r.distbits)-1;e:do{p<15&&(d+=z[n++]<<p,p+=8,d+=z[n++]<<p,p+=8),v=m[d&g];t:for(;;){if(d>>>=y=v>>>24,p-=y,0===(y=v>>>16&255))C[s++]=65535&v;else{if(!(16&y)){if(0==(64&y)){v=m[(65535&v)+(d&(1<<y)-1)];continue t}if(32&y){r.mode=12;break e}e.msg="invalid literal/length code",r.mode=30;break e}w=65535&v,(y&=15)&&(p<y&&(d+=z[n++]<<p,p+=8),w+=d&(1<<y)-1,d>>>=y,p-=y),p<15&&(d+=z[n++]<<p,p+=8,d+=z[n++]<<p,p+=8),v=_[d&b];r:for(;;){if(d>>>=y=v>>>24,p-=y,!(16&(y=v>>>16&255))){if(0==(64&y)){v=_[(65535&v)+(d&(1<<y)-1)];continue r}e.msg="invalid distance code",r.mode=30;break e}if(k=65535&v,p<(y&=15)&&(d+=z[n++]<<p,(p+=8)<y&&(d+=z[n++]<<p,p+=8)),h<(k+=d&(1<<y)-1)){e.msg="invalid distance too far back",r.mode=30;break e}if(d>>>=y,p-=y,(y=s-a)<k){if(l<(y=k-y)&&r.sane){e.msg="invalid distance too far back",r.mode=30;break e}if(S=c,(x=0)===f){if(x+=u-y,y<w){for(w-=y;C[s++]=c[x++],--y;);x=s-k,S=C}}else if(f<y){if(x+=u+f-y,(y-=f)<w){for(w-=y;C[s++]=c[x++],--y;);if(x=0,f<w){for(w-=y=f;C[s++]=c[x++],--y;);x=s-k,S=C}}}else if(x+=f-y,y<w){for(w-=y;C[s++]=c[x++],--y;);x=s-k,S=C}for(;2<w;)C[s++]=S[x++],C[s++]=S[x++],C[s++]=S[x++],w-=3;w&&(C[s++]=S[x++],1<w&&(C[s++]=S[x++]))}else{for(x=s-k;C[s++]=C[x++],C[s++]=C[x++],C[s++]=C[x++],2<(w-=3););w&&(C[s++]=C[x++],1<w&&(C[s++]=C[x++]))}break}}break}}while(n<i&&s<o);n-=w=p>>3,d&=(1<<(p-=w<<3))-1,e.next_in=n,e.next_out=s,e.avail_in=n<i?i-n+5:5-(n-i),e.avail_out=s<o?o-s+257:257-(s-o),r.hold=d,r.bits=p}},{}],49:[function(e,t,r){"use strict";var I=e("../utils/common"),O=e("./adler32"),B=e("./crc32"),R=e("./inffast"),T=e("./inftrees"),D=1,F=2,N=0,U=-2,P=1,n=852,i=592;function L(e){return(e>>>24&255)+(e>>>8&65280)+((65280&e)<<8)+((255&e)<<24)}function s(){this.mode=0,this.last=!1,this.wrap=0,this.havedict=!1,this.flags=0,this.dmax=0,this.check=0,this.total=0,this.head=null,this.wbits=0,this.wsize=0,this.whave=0,this.wnext=0,this.window=null,this.hold=0,this.bits=0,this.length=0,this.offset=0,this.extra=0,this.lencode=null,this.distcode=null,this.lenbits=0,this.distbits=0,this.ncode=0,this.nlen=0,this.ndist=0,this.have=0,this.next=null,this.lens=new I.Buf16(320),this.work=new I.Buf16(288),this.lendyn=null,this.distdyn=null,this.sane=0,this.back=0,this.was=0}function a(e){var t;return e&&e.state?(t=e.state,e.total_in=e.total_out=t.total=0,e.msg="",t.wrap&&(e.adler=1&t.wrap),t.mode=P,t.last=0,t.havedict=0,t.dmax=32768,t.head=null,t.hold=0,t.bits=0,t.lencode=t.lendyn=new I.Buf32(n),t.distcode=t.distdyn=new I.Buf32(i),t.sane=1,t.back=-1,N):U}function o(e){var t;return e&&e.state?((t=e.state).wsize=0,t.whave=0,t.wnext=0,a(e)):U}function h(e,t){var r,n;return e&&e.state?(n=e.state,t<0?(r=0,t=-t):(r=1+(t>>4),t<48&&(t&=15)),t&&(t<8||15<t)?U:(null!==n.window&&n.wbits!==t&&(n.window=null),n.wrap=r,n.wbits=t,o(e))):U}function u(e,t){var r,n;return e?(n=new s,(e.state=n).window=null,(r=h(e,t))!==N&&(e.state=null),r):U}var l,f,c=!0;function j(e){if(c){var t;for(l=new I.Buf32(512),f=new I.Buf32(32),t=0;t<144;)e.lens[t++]=8;for(;t<256;)e.lens[t++]=9;for(;t<280;)e.lens[t++]=7;for(;t<288;)e.lens[t++]=8;for(T(D,e.lens,0,288,l,0,e.work,{bits:9}),t=0;t<32;)e.lens[t++]=5;T(F,e.lens,0,32,f,0,e.work,{bits:5}),c=!1}e.lencode=l,e.lenbits=9,e.distcode=f,e.distbits=5}function Z(e,t,r,n){var i,s=e.state;return null===s.window&&(s.wsize=1<<s.wbits,s.wnext=0,s.whave=0,s.window=new I.Buf8(s.wsize)),n>=s.wsize?(I.arraySet(s.window,t,r-s.wsize,s.wsize,0),s.wnext=0,s.whave=s.wsize):(n<(i=s.wsize-s.wnext)&&(i=n),I.arraySet(s.window,t,r-n,i,s.wnext),(n-=i)?(I.arraySet(s.window,t,r-n,n,0),s.wnext=n,s.whave=s.wsize):(s.wnext+=i,s.wnext===s.wsize&&(s.wnext=0),s.whave<s.wsize&&(s.whave+=i))),0}r.inflateReset=o,r.inflateReset2=h,r.inflateResetKeep=a,r.inflateInit=function(e){return u(e,15)},r.inflateInit2=u,r.inflate=function(e,t){var r,n,i,s,a,o,h,u,l,f,c,d,p,m,_,g,b,v,y,w,k,x,S,z,C=0,E=new I.Buf8(4),A=[16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15];if(!e||!e.state||!e.output||!e.input&&0!==e.avail_in)return U;12===(r=e.state).mode&&(r.mode=13),a=e.next_out,i=e.output,h=e.avail_out,s=e.next_in,n=e.input,o=e.avail_in,u=r.hold,l=r.bits,f=o,c=h,x=N;e:for(;;)switch(r.mode){case P:if(0===r.wrap){r.mode=13;break}for(;l<16;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}if(2&r.wrap&&35615===u){E[r.check=0]=255&u,E[1]=u>>>8&255,r.check=B(r.check,E,2,0),l=u=0,r.mode=2;break}if(r.flags=0,r.head&&(r.head.done=!1),!(1&r.wrap)||(((255&u)<<8)+(u>>8))%31){e.msg="incorrect header check",r.mode=30;break}if(8!=(15&u)){e.msg="unknown compression method",r.mode=30;break}if(l-=4,k=8+(15&(u>>>=4)),0===r.wbits)r.wbits=k;else if(k>r.wbits){e.msg="invalid window size",r.mode=30;break}r.dmax=1<<k,e.adler=r.check=1,r.mode=512&u?10:12,l=u=0;break;case 2:for(;l<16;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}if(r.flags=u,8!=(255&r.flags)){e.msg="unknown compression method",r.mode=30;break}if(57344&r.flags){e.msg="unknown header flags set",r.mode=30;break}r.head&&(r.head.text=u>>8&1),512&r.flags&&(E[0]=255&u,E[1]=u>>>8&255,r.check=B(r.check,E,2,0)),l=u=0,r.mode=3;case 3:for(;l<32;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}r.head&&(r.head.time=u),512&r.flags&&(E[0]=255&u,E[1]=u>>>8&255,E[2]=u>>>16&255,E[3]=u>>>24&255,r.check=B(r.check,E,4,0)),l=u=0,r.mode=4;case 4:for(;l<16;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}r.head&&(r.head.xflags=255&u,r.head.os=u>>8),512&r.flags&&(E[0]=255&u,E[1]=u>>>8&255,r.check=B(r.check,E,2,0)),l=u=0,r.mode=5;case 5:if(1024&r.flags){for(;l<16;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}r.length=u,r.head&&(r.head.extra_len=u),512&r.flags&&(E[0]=255&u,E[1]=u>>>8&255,r.check=B(r.check,E,2,0)),l=u=0}else r.head&&(r.head.extra=null);r.mode=6;case 6:if(1024&r.flags&&(o<(d=r.length)&&(d=o),d&&(r.head&&(k=r.head.extra_len-r.length,r.head.extra||(r.head.extra=new Array(r.head.extra_len)),I.arraySet(r.head.extra,n,s,d,k)),512&r.flags&&(r.check=B(r.check,n,d,s)),o-=d,s+=d,r.length-=d),r.length))break e;r.length=0,r.mode=7;case 7:if(2048&r.flags){if(0===o)break e;for(d=0;k=n[s+d++],r.head&&k&&r.length<65536&&(r.head.name+=String.fromCharCode(k)),k&&d<o;);if(512&r.flags&&(r.check=B(r.check,n,d,s)),o-=d,s+=d,k)break e}else r.head&&(r.head.name=null);r.length=0,r.mode=8;case 8:if(4096&r.flags){if(0===o)break e;for(d=0;k=n[s+d++],r.head&&k&&r.length<65536&&(r.head.comment+=String.fromCharCode(k)),k&&d<o;);if(512&r.flags&&(r.check=B(r.check,n,d,s)),o-=d,s+=d,k)break e}else r.head&&(r.head.comment=null);r.mode=9;case 9:if(512&r.flags){for(;l<16;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}if(u!==(65535&r.check)){e.msg="header crc mismatch",r.mode=30;break}l=u=0}r.head&&(r.head.hcrc=r.flags>>9&1,r.head.done=!0),e.adler=r.check=0,r.mode=12;break;case 10:for(;l<32;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}e.adler=r.check=L(u),l=u=0,r.mode=11;case 11:if(0===r.havedict)return e.next_out=a,e.avail_out=h,e.next_in=s,e.avail_in=o,r.hold=u,r.bits=l,2;e.adler=r.check=1,r.mode=12;case 12:if(5===t||6===t)break e;case 13:if(r.last){u>>>=7&l,l-=7&l,r.mode=27;break}for(;l<3;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}switch(r.last=1&u,l-=1,3&(u>>>=1)){case 0:r.mode=14;break;case 1:if(j(r),r.mode=20,6!==t)break;u>>>=2,l-=2;break e;case 2:r.mode=17;break;case 3:e.msg="invalid block type",r.mode=30}u>>>=2,l-=2;break;case 14:for(u>>>=7&l,l-=7&l;l<32;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}if((65535&u)!=(u>>>16^65535)){e.msg="invalid stored block lengths",r.mode=30;break}if(r.length=65535&u,l=u=0,r.mode=15,6===t)break e;case 15:r.mode=16;case 16:if(d=r.length){if(o<d&&(d=o),h<d&&(d=h),0===d)break e;I.arraySet(i,n,s,d,a),o-=d,s+=d,h-=d,a+=d,r.length-=d;break}r.mode=12;break;case 17:for(;l<14;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}if(r.nlen=257+(31&u),u>>>=5,l-=5,r.ndist=1+(31&u),u>>>=5,l-=5,r.ncode=4+(15&u),u>>>=4,l-=4,286<r.nlen||30<r.ndist){e.msg="too many length or distance symbols",r.mode=30;break}r.have=0,r.mode=18;case 18:for(;r.have<r.ncode;){for(;l<3;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}r.lens[A[r.have++]]=7&u,u>>>=3,l-=3}for(;r.have<19;)r.lens[A[r.have++]]=0;if(r.lencode=r.lendyn,r.lenbits=7,S={bits:r.lenbits},x=T(0,r.lens,0,19,r.lencode,0,r.work,S),r.lenbits=S.bits,x){e.msg="invalid code lengths set",r.mode=30;break}r.have=0,r.mode=19;case 19:for(;r.have<r.nlen+r.ndist;){for(;g=(C=r.lencode[u&(1<<r.lenbits)-1])>>>16&255,b=65535&C,!((_=C>>>24)<=l);){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}if(b<16)u>>>=_,l-=_,r.lens[r.have++]=b;else{if(16===b){for(z=_+2;l<z;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}if(u>>>=_,l-=_,0===r.have){e.msg="invalid bit length repeat",r.mode=30;break}k=r.lens[r.have-1],d=3+(3&u),u>>>=2,l-=2}else if(17===b){for(z=_+3;l<z;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}l-=_,k=0,d=3+(7&(u>>>=_)),u>>>=3,l-=3}else{for(z=_+7;l<z;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}l-=_,k=0,d=11+(127&(u>>>=_)),u>>>=7,l-=7}if(r.have+d>r.nlen+r.ndist){e.msg="invalid bit length repeat",r.mode=30;break}for(;d--;)r.lens[r.have++]=k}}if(30===r.mode)break;if(0===r.lens[256]){e.msg="invalid code -- missing end-of-block",r.mode=30;break}if(r.lenbits=9,S={bits:r.lenbits},x=T(D,r.lens,0,r.nlen,r.lencode,0,r.work,S),r.lenbits=S.bits,x){e.msg="invalid literal/lengths set",r.mode=30;break}if(r.distbits=6,r.distcode=r.distdyn,S={bits:r.distbits},x=T(F,r.lens,r.nlen,r.ndist,r.distcode,0,r.work,S),r.distbits=S.bits,x){e.msg="invalid distances set",r.mode=30;break}if(r.mode=20,6===t)break e;case 20:r.mode=21;case 21:if(6<=o&&258<=h){e.next_out=a,e.avail_out=h,e.next_in=s,e.avail_in=o,r.hold=u,r.bits=l,R(e,c),a=e.next_out,i=e.output,h=e.avail_out,s=e.next_in,n=e.input,o=e.avail_in,u=r.hold,l=r.bits,12===r.mode&&(r.back=-1);break}for(r.back=0;g=(C=r.lencode[u&(1<<r.lenbits)-1])>>>16&255,b=65535&C,!((_=C>>>24)<=l);){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}if(g&&0==(240&g)){for(v=_,y=g,w=b;g=(C=r.lencode[w+((u&(1<<v+y)-1)>>v)])>>>16&255,b=65535&C,!(v+(_=C>>>24)<=l);){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}u>>>=v,l-=v,r.back+=v}if(u>>>=_,l-=_,r.back+=_,r.length=b,0===g){r.mode=26;break}if(32&g){r.back=-1,r.mode=12;break}if(64&g){e.msg="invalid literal/length code",r.mode=30;break}r.extra=15&g,r.mode=22;case 22:if(r.extra){for(z=r.extra;l<z;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}r.length+=u&(1<<r.extra)-1,u>>>=r.extra,l-=r.extra,r.back+=r.extra}r.was=r.length,r.mode=23;case 23:for(;g=(C=r.distcode[u&(1<<r.distbits)-1])>>>16&255,b=65535&C,!((_=C>>>24)<=l);){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}if(0==(240&g)){for(v=_,y=g,w=b;g=(C=r.distcode[w+((u&(1<<v+y)-1)>>v)])>>>16&255,b=65535&C,!(v+(_=C>>>24)<=l);){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}u>>>=v,l-=v,r.back+=v}if(u>>>=_,l-=_,r.back+=_,64&g){e.msg="invalid distance code",r.mode=30;break}r.offset=b,r.extra=15&g,r.mode=24;case 24:if(r.extra){for(z=r.extra;l<z;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}r.offset+=u&(1<<r.extra)-1,u>>>=r.extra,l-=r.extra,r.back+=r.extra}if(r.offset>r.dmax){e.msg="invalid distance too far back",r.mode=30;break}r.mode=25;case 25:if(0===h)break e;if(d=c-h,r.offset>d){if((d=r.offset-d)>r.whave&&r.sane){e.msg="invalid distance too far back",r.mode=30;break}p=d>r.wnext?(d-=r.wnext,r.wsize-d):r.wnext-d,d>r.length&&(d=r.length),m=r.window}else m=i,p=a-r.offset,d=r.length;for(h<d&&(d=h),h-=d,r.length-=d;i[a++]=m[p++],--d;);0===r.length&&(r.mode=21);break;case 26:if(0===h)break e;i[a++]=r.length,h--,r.mode=21;break;case 27:if(r.wrap){for(;l<32;){if(0===o)break e;o--,u|=n[s++]<<l,l+=8}if(c-=h,e.total_out+=c,r.total+=c,c&&(e.adler=r.check=r.flags?B(r.check,i,c,a-c):O(r.check,i,c,a-c)),c=h,(r.flags?u:L(u))!==r.check){e.msg="incorrect data check",r.mode=30;break}l=u=0}r.mode=28;case 28:if(r.wrap&&r.flags){for(;l<32;){if(0===o)break e;o--,u+=n[s++]<<l,l+=8}if(u!==(4294967295&r.total)){e.msg="incorrect length check",r.mode=30;break}l=u=0}r.mode=29;case 29:x=1;break e;case 30:x=-3;break e;case 31:return-4;case 32:default:return U}return e.next_out=a,e.avail_out=h,e.next_in=s,e.avail_in=o,r.hold=u,r.bits=l,(r.wsize||c!==e.avail_out&&r.mode<30&&(r.mode<27||4!==t))&&Z(e,e.output,e.next_out,c-e.avail_out)?(r.mode=31,-4):(f-=e.avail_in,c-=e.avail_out,e.total_in+=f,e.total_out+=c,r.total+=c,r.wrap&&c&&(e.adler=r.check=r.flags?B(r.check,i,c,e.next_out-c):O(r.check,i,c,e.next_out-c)),e.data_type=r.bits+(r.last?64:0)+(12===r.mode?128:0)+(20===r.mode||15===r.mode?256:0),(0==f&&0===c||4===t)&&x===N&&(x=-5),x)},r.inflateEnd=function(e){if(!e||!e.state)return U;var t=e.state;return t.window&&(t.window=null),e.state=null,N},r.inflateGetHeader=function(e,t){var r;return e&&e.state?0==(2&(r=e.state).wrap)?U:((r.head=t).done=!1,N):U},r.inflateSetDictionary=function(e,t){var r,n=t.length;return e&&e.state?0!==(r=e.state).wrap&&11!==r.mode?U:11===r.mode&&O(1,t,n,0)!==r.check?-3:Z(e,t,n,n)?(r.mode=31,-4):(r.havedict=1,N):U},r.inflateInfo="pako inflate (from Nodeca project)"},{"../utils/common":41,"./adler32":43,"./crc32":45,"./inffast":48,"./inftrees":50}],50:[function(e,t,r){"use strict";var D=e("../utils/common"),F=[3,4,5,6,7,8,9,10,11,13,15,17,19,23,27,31,35,43,51,59,67,83,99,115,131,163,195,227,258,0,0],N=[16,16,16,16,16,16,16,16,17,17,17,17,18,18,18,18,19,19,19,19,20,20,20,20,21,21,21,21,16,72,78],U=[1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577,0,0],P=[16,16,16,16,17,17,18,18,19,19,20,20,21,21,22,22,23,23,24,24,25,25,26,26,27,27,28,28,29,29,64,64];t.exports=function(e,t,r,n,i,s,a,o){var h,u,l,f,c,d,p,m,_,g=o.bits,b=0,v=0,y=0,w=0,k=0,x=0,S=0,z=0,C=0,E=0,A=null,I=0,O=new D.Buf16(16),B=new D.Buf16(16),R=null,T=0;for(b=0;b<=15;b++)O[b]=0;for(v=0;v<n;v++)O[t[r+v]]++;for(k=g,w=15;1<=w&&0===O[w];w--);if(w<k&&(k=w),0===w)return i[s++]=20971520,i[s++]=20971520,o.bits=1,0;for(y=1;y<w&&0===O[y];y++);for(k<y&&(k=y),b=z=1;b<=15;b++)if(z<<=1,(z-=O[b])<0)return-1;if(0<z&&(0===e||1!==w))return-1;for(B[1]=0,b=1;b<15;b++)B[b+1]=B[b]+O[b];for(v=0;v<n;v++)0!==t[r+v]&&(a[B[t[r+v]]++]=v);if(d=0===e?(A=R=a,19):1===e?(A=F,I-=257,R=N,T-=257,256):(A=U,R=P,-1),b=y,c=s,S=v=E=0,l=-1,f=(C=1<<(x=k))-1,1===e&&852<C||2===e&&592<C)return 1;for(;;){for(p=b-S,_=a[v]<d?(m=0,a[v]):a[v]>d?(m=R[T+a[v]],A[I+a[v]]):(m=96,0),h=1<<b-S,y=u=1<<x;i[c+(E>>S)+(u-=h)]=p<<24|m<<16|_|0,0!==u;);for(h=1<<b-1;E&h;)h>>=1;if(0!==h?(E&=h-1,E+=h):E=0,v++,0==--O[b]){if(b===w)break;b=t[r+a[v]]}if(k<b&&(E&f)!==l){for(0===S&&(S=k),c+=y,z=1<<(x=b-S);x+S<w&&!((z-=O[x+S])<=0);)x++,z<<=1;if(C+=1<<x,1===e&&852<C||2===e&&592<C)return 1;i[l=E&f]=k<<24|x<<16|c-s|0}}return 0!==E&&(i[c+E]=b-S<<24|64<<16|0),o.bits=k,0}},{"../utils/common":41}],51:[function(e,t,r){"use strict";t.exports={2:"need dictionary",1:"stream end",0:"","-1":"file error","-2":"stream error","-3":"data error","-4":"insufficient memory","-5":"buffer error","-6":"incompatible version"}},{}],52:[function(e,t,r){"use strict";var i=e("../utils/common"),o=0,h=1;function n(e){for(var t=e.length;0<=--t;)e[t]=0}var s=0,a=29,u=256,l=u+1+a,f=30,c=19,_=2*l+1,g=15,d=16,p=7,m=256,b=16,v=17,y=18,w=[0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0],k=[0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13],x=[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,3,7],S=[16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15],z=new Array(2*(l+2));n(z);var C=new Array(2*f);n(C);var E=new Array(512);n(E);var A=new Array(256);n(A);var I=new Array(a);n(I);var O,B,R,T=new Array(f);function D(e,t,r,n,i){this.static_tree=e,this.extra_bits=t,this.extra_base=r,this.elems=n,this.max_length=i,this.has_stree=e&&e.length}function F(e,t){this.dyn_tree=e,this.max_code=0,this.stat_desc=t}function N(e){return e<256?E[e]:E[256+(e>>>7)]}function U(e,t){e.pending_buf[e.pending++]=255&t,e.pending_buf[e.pending++]=t>>>8&255}function P(e,t,r){e.bi_valid>d-r?(e.bi_buf|=t<<e.bi_valid&65535,U(e,e.bi_buf),e.bi_buf=t>>d-e.bi_valid,e.bi_valid+=r-d):(e.bi_buf|=t<<e.bi_valid&65535,e.bi_valid+=r)}function L(e,t,r){P(e,r[2*t],r[2*t+1])}function j(e,t){for(var r=0;r|=1&e,e>>>=1,r<<=1,0<--t;);return r>>>1}function Z(e,t,r){var n,i,s=new Array(g+1),a=0;for(n=1;n<=g;n++)s[n]=a=a+r[n-1]<<1;for(i=0;i<=t;i++){var o=e[2*i+1];0!==o&&(e[2*i]=j(s[o]++,o))}}function W(e){var t;for(t=0;t<l;t++)e.dyn_ltree[2*t]=0;for(t=0;t<f;t++)e.dyn_dtree[2*t]=0;for(t=0;t<c;t++)e.bl_tree[2*t]=0;e.dyn_ltree[2*m]=1,e.opt_len=e.static_len=0,e.last_lit=e.matches=0}function M(e){8<e.bi_valid?U(e,e.bi_buf):0<e.bi_valid&&(e.pending_buf[e.pending++]=e.bi_buf),e.bi_buf=0,e.bi_valid=0}function H(e,t,r,n){var i=2*t,s=2*r;return e[i]<e[s]||e[i]===e[s]&&n[t]<=n[r]}function G(e,t,r){for(var n=e.heap[r],i=r<<1;i<=e.heap_len&&(i<e.heap_len&&H(t,e.heap[i+1],e.heap[i],e.depth)&&i++,!H(t,n,e.heap[i],e.depth));)e.heap[r]=e.heap[i],r=i,i<<=1;e.heap[r]=n}function K(e,t,r){var n,i,s,a,o=0;if(0!==e.last_lit)for(;n=e.pending_buf[e.d_buf+2*o]<<8|e.pending_buf[e.d_buf+2*o+1],i=e.pending_buf[e.l_buf+o],o++,0===n?L(e,i,t):(L(e,(s=A[i])+u+1,t),0!==(a=w[s])&&P(e,i-=I[s],a),L(e,s=N(--n),r),0!==(a=k[s])&&P(e,n-=T[s],a)),o<e.last_lit;);L(e,m,t)}function Y(e,t){var r,n,i,s=t.dyn_tree,a=t.stat_desc.static_tree,o=t.stat_desc.has_stree,h=t.stat_desc.elems,u=-1;for(e.heap_len=0,e.heap_max=_,r=0;r<h;r++)0!==s[2*r]?(e.heap[++e.heap_len]=u=r,e.depth[r]=0):s[2*r+1]=0;for(;e.heap_len<2;)s[2*(i=e.heap[++e.heap_len]=u<2?++u:0)]=1,e.depth[i]=0,e.opt_len--,o&&(e.static_len-=a[2*i+1]);for(t.max_code=u,r=e.heap_len>>1;1<=r;r--)G(e,s,r);for(i=h;r=e.heap[1],e.heap[1]=e.heap[e.heap_len--],G(e,s,1),n=e.heap[1],e.heap[--e.heap_max]=r,e.heap[--e.heap_max]=n,s[2*i]=s[2*r]+s[2*n],e.depth[i]=(e.depth[r]>=e.depth[n]?e.depth[r]:e.depth[n])+1,s[2*r+1]=s[2*n+1]=i,e.heap[1]=i++,G(e,s,1),2<=e.heap_len;);e.heap[--e.heap_max]=e.heap[1],function(e,t){var r,n,i,s,a,o,h=t.dyn_tree,u=t.max_code,l=t.stat_desc.static_tree,f=t.stat_desc.has_stree,c=t.stat_desc.extra_bits,d=t.stat_desc.extra_base,p=t.stat_desc.max_length,m=0;for(s=0;s<=g;s++)e.bl_count[s]=0;for(h[2*e.heap[e.heap_max]+1]=0,r=e.heap_max+1;r<_;r++)p<(s=h[2*h[2*(n=e.heap[r])+1]+1]+1)&&(s=p,m++),h[2*n+1]=s,u<n||(e.bl_count[s]++,a=0,d<=n&&(a=c[n-d]),o=h[2*n],e.opt_len+=o*(s+a),f&&(e.static_len+=o*(l[2*n+1]+a)));if(0!==m){do{for(s=p-1;0===e.bl_count[s];)s--;e.bl_count[s]--,e.bl_count[s+1]+=2,e.bl_count[p]--,m-=2}while(0<m);for(s=p;0!==s;s--)for(n=e.bl_count[s];0!==n;)u<(i=e.heap[--r])||(h[2*i+1]!==s&&(e.opt_len+=(s-h[2*i+1])*h[2*i],h[2*i+1]=s),n--)}}(e,t),Z(s,u,e.bl_count)}function X(e,t,r){var n,i,s=-1,a=t[1],o=0,h=7,u=4;for(0===a&&(h=138,u=3),t[2*(r+1)+1]=65535,n=0;n<=r;n++)i=a,a=t[2*(n+1)+1],++o<h&&i===a||(o<u?e.bl_tree[2*i]+=o:0!==i?(i!==s&&e.bl_tree[2*i]++,e.bl_tree[2*b]++):o<=10?e.bl_tree[2*v]++:e.bl_tree[2*y]++,s=i,u=(o=0)===a?(h=138,3):i===a?(h=6,3):(h=7,4))}function V(e,t,r){var n,i,s=-1,a=t[1],o=0,h=7,u=4;for(0===a&&(h=138,u=3),n=0;n<=r;n++)if(i=a,a=t[2*(n+1)+1],!(++o<h&&i===a)){if(o<u)for(;L(e,i,e.bl_tree),0!=--o;);else 0!==i?(i!==s&&(L(e,i,e.bl_tree),o--),L(e,b,e.bl_tree),P(e,o-3,2)):o<=10?(L(e,v,e.bl_tree),P(e,o-3,3)):(L(e,y,e.bl_tree),P(e,o-11,7));s=i,u=(o=0)===a?(h=138,3):i===a?(h=6,3):(h=7,4)}}n(T);var q=!1;function J(e,t,r,n){P(e,(s<<1)+(n?1:0),3),function(e,t,r,n){M(e),n&&(U(e,r),U(e,~r)),i.arraySet(e.pending_buf,e.window,t,r,e.pending),e.pending+=r}(e,t,r,!0)}r._tr_init=function(e){q||(function(){var e,t,r,n,i,s=new Array(g+1);for(n=r=0;n<a-1;n++)for(I[n]=r,e=0;e<1<<w[n];e++)A[r++]=n;for(A[r-1]=n,n=i=0;n<16;n++)for(T[n]=i,e=0;e<1<<k[n];e++)E[i++]=n;for(i>>=7;n<f;n++)for(T[n]=i<<7,e=0;e<1<<k[n]-7;e++)E[256+i++]=n;for(t=0;t<=g;t++)s[t]=0;for(e=0;e<=143;)z[2*e+1]=8,e++,s[8]++;for(;e<=255;)z[2*e+1]=9,e++,s[9]++;for(;e<=279;)z[2*e+1]=7,e++,s[7]++;for(;e<=287;)z[2*e+1]=8,e++,s[8]++;for(Z(z,l+1,s),e=0;e<f;e++)C[2*e+1]=5,C[2*e]=j(e,5);O=new D(z,w,u+1,l,g),B=new D(C,k,0,f,g),R=new D(new Array(0),x,0,c,p)}(),q=!0),e.l_desc=new F(e.dyn_ltree,O),e.d_desc=new F(e.dyn_dtree,B),e.bl_desc=new F(e.bl_tree,R),e.bi_buf=0,e.bi_valid=0,W(e)},r._tr_stored_block=J,r._tr_flush_block=function(e,t,r,n){var i,s,a=0;0<e.level?(2===e.strm.data_type&&(e.strm.data_type=function(e){var t,r=4093624447;for(t=0;t<=31;t++,r>>>=1)if(1&r&&0!==e.dyn_ltree[2*t])return o;if(0!==e.dyn_ltree[18]||0!==e.dyn_ltree[20]||0!==e.dyn_ltree[26])return h;for(t=32;t<u;t++)if(0!==e.dyn_ltree[2*t])return h;return o}(e)),Y(e,e.l_desc),Y(e,e.d_desc),a=function(e){var t;for(X(e,e.dyn_ltree,e.l_desc.max_code),X(e,e.dyn_dtree,e.d_desc.max_code),Y(e,e.bl_desc),t=c-1;3<=t&&0===e.bl_tree[2*S[t]+1];t--);return e.opt_len+=3*(t+1)+5+5+4,t}(e),i=e.opt_len+3+7>>>3,(s=e.static_len+3+7>>>3)<=i&&(i=s)):i=s=r+5,r+4<=i&&-1!==t?J(e,t,r,n):4===e.strategy||s===i?(P(e,2+(n?1:0),3),K(e,z,C)):(P(e,4+(n?1:0),3),function(e,t,r,n){var i;for(P(e,t-257,5),P(e,r-1,5),P(e,n-4,4),i=0;i<n;i++)P(e,e.bl_tree[2*S[i]+1],3);V(e,e.dyn_ltree,t-1),V(e,e.dyn_dtree,r-1)}(e,e.l_desc.max_code+1,e.d_desc.max_code+1,a+1),K(e,e.dyn_ltree,e.dyn_dtree)),W(e),n&&M(e)},r._tr_tally=function(e,t,r){return e.pending_buf[e.d_buf+2*e.last_lit]=t>>>8&255,e.pending_buf[e.d_buf+2*e.last_lit+1]=255&t,e.pending_buf[e.l_buf+e.last_lit]=255&r,e.last_lit++,0===t?e.dyn_ltree[2*r]++:(e.matches++,t--,e.dyn_ltree[2*(A[r]+u+1)]++,e.dyn_dtree[2*N(t)]++),e.last_lit===e.lit_bufsize-1},r._tr_align=function(e){P(e,2,3),L(e,m,z),function(e){16===e.bi_valid?(U(e,e.bi_buf),e.bi_buf=0,e.bi_valid=0):8<=e.bi_valid&&(e.pending_buf[e.pending++]=255&e.bi_buf,e.bi_buf>>=8,e.bi_valid-=8)}(e)}},{"../utils/common":41}],53:[function(e,t,r){"use strict";t.exports=function(){this.input=null,this.next_in=0,this.avail_in=0,this.total_in=0,this.output=null,this.next_out=0,this.avail_out=0,this.total_out=0,this.msg="",this.state=null,this.data_type=2,this.adler=0}},{}],54:[function(e,t,r){(function(e){!function(r,n){"use strict";if(!r.setImmediate){var i,s,t,a,o=1,h={},u=!1,l=r.document,e=Object.getPrototypeOf&&Object.getPrototypeOf(r);e=e&&e.setTimeout?e:r,i="[object process]"==={}.toString.call(r.process)?function(e){process.nextTick(function(){c(e)})}:function(){if(r.postMessage&&!r.importScripts){var e=!0,t=r.onmessage;return r.onmessage=function(){e=!1},r.postMessage("","*"),r.onmessage=t,e}}()?(a="setImmediate$"+Math.random()+"$",r.addEventListener?r.addEventListener("message",d,!1):r.attachEvent("onmessage",d),function(e){r.postMessage(a+e,"*")}):r.MessageChannel?((t=new MessageChannel).port1.onmessage=function(e){c(e.data)},function(e){t.port2.postMessage(e)}):l&&"onreadystatechange"in l.createElement("script")?(s=l.documentElement,function(e){var t=l.createElement("script");t.onreadystatechange=function(){c(e),t.onreadystatechange=null,s.removeChild(t),t=null},s.appendChild(t)}):function(e){setTimeout(c,0,e)},e.setImmediate=function(e){"function"!=typeof e&&(e=new Function(""+e));for(var t=new Array(arguments.length-1),r=0;r<t.length;r++)t[r]=arguments[r+1];var n={callback:e,args:t};return h[o]=n,i(o),o++},e.clearImmediate=f}function f(e){delete h[e]}function c(e){if(u)setTimeout(c,0,e);else{var t=h[e];if(t){u=!0;try{!function(e){var t=e.callback,r=e.args;switch(r.length){case 0:t();break;case 1:t(r[0]);break;case 2:t(r[0],r[1]);break;case 3:t(r[0],r[1],r[2]);break;default:t.apply(n,r)}}(t)}finally{f(e),u=!1}}}}function d(e){e.source===r&&"string"==typeof e.data&&0===e.data.indexOf(a)&&c(+e.data.slice(a.length))}}("undefined"==typeof self?void 0===e?this:e:self)}).call(this,"undefined"!=typeof __webpack_require__.g?__webpack_require__.g:"undefined"!=typeof self?self:"undefined"!=typeof window?window:{})},{}]},{},[10])(10)});
 
-/***/ }),
+/***/ },
 
-/***/ 108:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ 236
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   c: () => (/* binding */ lexer)
-/* harmony export */ });
-/* harmony import */ var _tokenTypes__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(307);
-/* harmony import */ var _utils__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(465);
+/* harmony import */ var _tokenTypes__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(278);
+/* harmony import */ var _utils__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(379);
 
 
 /**
@@ -115,7 +77,7 @@ const lexer = (input, type) => {
             let p = document.createElement("p");
             p.innerHTML = dom.closest('.PinItem-content-originpin').firstElementChild.textContent;
             pinParagraphs.push({
-                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Text,
+                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Text,
                 content: Tokenize(p),
             });
         }
@@ -126,7 +88,7 @@ const lexer = (input, type) => {
             let p = document.createElement("p");
             p.innerHTML = block;
             pinParagraphs.push({
-                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Text,
+                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Text,
                 content: Tokenize(p),
             });
         }
@@ -140,7 +102,7 @@ const lexer = (input, type) => {
                 a2.innerHTML = a.innerText.replace(/\n\s*/g, " ");
                 p.innerHTML = a2.outerHTML;
                 pinParagraphs.push({
-                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Text,
+                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Text,
                     content: Tokenize(p),
                 });
             }
@@ -156,7 +118,7 @@ const lexer = (input, type) => {
                 a2.innerHTML = a.innerText.replace(/\n\s*/g, " ");
                 p.innerHTML = a2.outerHTML;
                 pinParagraphs.push({
-                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Text,
+                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Text,
                     content: Tokenize(p),
                 });
             }
@@ -174,7 +136,7 @@ const lexer = (input, type) => {
         switch (tagName) {
             case "h2": {
                 tokens.push({
-                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.H2,
+                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.H2,
                     text: node.textContent,
                     dom: node
                 });
@@ -182,7 +144,7 @@ const lexer = (input, type) => {
             }
             case "h3": {
                 tokens.push({
-                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.H3,
+                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.H3,
                     text: node.textContent,
                     dom: node
                 });
@@ -191,7 +153,7 @@ const lexer = (input, type) => {
             case "div": {
                 if (node.classList.contains("highlight")) {
                     tokens.push({
-                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Code,
+                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Code,
                         content: node.textContent,
                         language: node.querySelector("pre > code").classList.value.slice(9),
                         dom: node
@@ -200,15 +162,15 @@ const lexer = (input, type) => {
                 else if (node.classList.contains("RichText-LinkCardContainer")) {
                     const link = node.firstChild;
                     tokens.push({
-                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Link,
+                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Link,
                         text: link.getAttribute("data-text"),
-                        href: (0,_utils__WEBPACK_IMPORTED_MODULE_1__/* .ZhihuLink2NormalLink */ .ld)(link.href),
+                        href: (0,_utils__WEBPACK_IMPORTED_MODULE_1__/* .ZhihuLink2NormalLink */ .IQ)(link.href),
                         dom: node
                     });
                 }
                 else if (node.querySelector("video")) {
                     tokens.push({
-                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Video,
+                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Video,
                         src: node.querySelector("video").getAttribute("src"),
                         local: false,
                         dom: node
@@ -216,9 +178,9 @@ const lexer = (input, type) => {
                 }
                 else if (node.classList.contains("RichText-ADLinkCardContainer")) {
                     tokens.push({
-                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Text,
+                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Text,
                         content: [{
-                                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.PlainText,
+                                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.PlainText,
                                 text: node.textContent
                             }],
                         dom: node
@@ -228,7 +190,7 @@ const lexer = (input, type) => {
             }
             case "blockquote": {
                 tokens.push({
-                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Blockquote,
+                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Blockquote,
                     content: Tokenize(node),
                     dom: node
                 });
@@ -243,7 +205,7 @@ const lexer = (input, type) => {
                     const src = guessSrc(img.getAttribute("src") || img.getAttribute("data-thumbnail"));
                     if (src) {
                         tokens.push({
-                            type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Gif,
+                            type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Gif,
                             src,
                             local: false,
                             dom: node
@@ -255,9 +217,9 @@ const lexer = (input, type) => {
                     const altText = img.getAttribute('alt') || '';
                     if (altText) {
                         tokens.push({
-                            type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Text,
+                            type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Text,
                             content: [{
-                                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Math,
+                                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Math,
                                     content: altText.trim(),
                                     display: true,
                                     dom: img
@@ -270,7 +232,7 @@ const lexer = (input, type) => {
                     const src = img.getAttribute("data-actualsrc") || img.getAttribute("data-original") || img.src;
                     if (src) {
                         tokens.push({
-                            type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Figure,
+                            type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Figure,
                             src,
                             local: false,
                             dom: node
@@ -281,9 +243,9 @@ const lexer = (input, type) => {
                 const text = node.querySelector("figcaption");
                 if (text) {
                     tokens.push({
-                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Text,
+                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Text,
                         content: [{
-                                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Italic,
+                                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Italic,
                                 content: Tokenize(text),
                                 dom: text,
                             }],
@@ -295,7 +257,7 @@ const lexer = (input, type) => {
             case "ul": {
                 const childNodes = Array.from(node.querySelectorAll("li"));
                 tokens.push({
-                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.UList,
+                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.UList,
                     content: childNodes.map((el) => Tokenize(el)),
                     dom: node,
                 });
@@ -314,7 +276,7 @@ const lexer = (input, type) => {
                         return { id, content: content.trim() };
                     });
                     tokens.push({
-                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.FootnoteList,
+                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.FootnoteList,
                         items,
                         dom: node,
                     });
@@ -323,7 +285,7 @@ const lexer = (input, type) => {
                     // 普通有序列表
                     const childNodes = Array.from(node.querySelectorAll("li"));
                     tokens.push({
-                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Olist,
+                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Olist,
                         content: childNodes.map((el) => Tokenize(el)),
                         dom: node,
                     });
@@ -334,7 +296,7 @@ const lexer = (input, type) => {
                 if (skipEmpty && (node.classList.contains('ztext-empty-paragraph') || node.textContent.length == 0))
                     break;
                 tokens.push({
-                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Text,
+                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Text,
                     content: Tokenize(node),
                     dom: node
                 });
@@ -342,7 +304,7 @@ const lexer = (input, type) => {
             }
             case "hr": {
                 tokens.push({
-                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.HR,
+                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.HR,
                     dom: node
                 });
                 break;
@@ -360,7 +322,7 @@ const lexer = (input, type) => {
                 };
                 const table = table2array(el);
                 tokens.push({
-                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Table,
+                    type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Table,
                     content: table,
                     dom: node,
                 });
@@ -380,7 +342,7 @@ const lexer = (input, type) => {
 const Tokenize = (node) => {
     if (typeof node == "string") {
         return [{
-                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.PlainText,
+                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.PlainText,
                 text: node.replace('\t', '').replace(/^\s{2,}/, ''), // 修复被误识别为代码块，修复公式后面缺少空格的问题
             }];
     }
@@ -396,7 +358,7 @@ const Tokenize = (node) => {
     for (let child of childs) {
         if (child.nodeType == child.TEXT_NODE) {
             res.push({
-                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.PlainText,
+                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.PlainText,
                 text: child.textContent.replace(/\u200B/g, '').replace('\t', '').replace(/^\s{2,}/, ''), // 修复被误识别为代码块，修复公式后面缺少空格的问题
                 dom: child,
             });
@@ -406,7 +368,7 @@ const Tokenize = (node) => {
             switch (el.tagName.toLowerCase()) {
                 case "b": {
                     res.push({
-                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Bold,
+                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Bold,
                         content: Tokenize(el),
                         dom: el,
                     });
@@ -414,7 +376,7 @@ const Tokenize = (node) => {
                 }
                 case "i": {
                     res.push({
-                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Italic,
+                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Italic,
                         content: Tokenize(el),
                         dom: el,
                     });
@@ -422,14 +384,14 @@ const Tokenize = (node) => {
                 }
                 case "br": {
                     res.push({
-                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.BR,
+                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.BR,
                         dom: el,
                     });
                     break;
                 }
                 case "code": {
                     res.push({
-                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.InlineCode,
+                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.InlineCode,
                         content: el.innerText,
                         dom: el,
                     });
@@ -445,7 +407,7 @@ const Tokenize = (node) => {
                             const hasTag = content.includes('\\tag');
                             const isDisplayMath = hasDisplayClass || hasTag;
                             res.push({
-                                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Math,
+                                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Math,
                                 content: content,
                                 display: isDisplayMath,
                                 dom: el,
@@ -453,23 +415,23 @@ const Tokenize = (node) => {
                         }
                         else if (el.children[0].classList.contains("RichContent-EntityWord")) { //搜索词
                             res.push({
-                                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.PlainText,
+                                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.PlainText,
                                 text: el.innerText,
                                 dom: el,
                             });
                         }
                         else if (el.querySelector('a')) { //想法中的用户名片
                             res.push({
-                                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.InlineLink,
+                                type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.InlineLink,
                                 text: el.innerText,
-                                href: (0,_utils__WEBPACK_IMPORTED_MODULE_1__/* .ZhihuLink2NormalLink */ .ld)(el.querySelector("a").href),
+                                href: (0,_utils__WEBPACK_IMPORTED_MODULE_1__/* .ZhihuLink2NormalLink */ .IQ)(el.querySelector("a").href),
                                 dom: el,
                             });
                         }
                     }
                     catch (e) {
                         res.push({
-                            type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.PlainText,
+                            type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.PlainText,
                             text: el.innerText,
                             dom: el,
                         });
@@ -482,16 +444,16 @@ const Tokenize = (node) => {
                     // 移除另一种搜索推荐
                     if (el.href.startsWith('https://zhida.zhihu.com/search')) {
                         res.push({
-                            type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.PlainText,
+                            type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.PlainText,
                             text: el.innerText,
                             dom: el,
                         });
                     }
                     else
                         res.push({
-                            type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.InlineLink,
+                            type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.InlineLink,
                             text: el.textContent,
-                            href: (0,_utils__WEBPACK_IMPORTED_MODULE_1__/* .ZhihuLink2NormalLink */ .ld)(el.href),
+                            href: (0,_utils__WEBPACK_IMPORTED_MODULE_1__/* .ZhihuLink2NormalLink */ .IQ)(el.href),
                             dom: el,
                         });
                     break;
@@ -501,7 +463,7 @@ const Tokenize = (node) => {
                     // 提取脚注编号，如 [1] -> 1
                     const footnoteText = link.textContent.replace(/[\[\]]/g, '');
                     res.push({
-                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.PlainText,
+                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.PlainText,
                         text: `[^${footnoteText}]`,
                         dom: el,
                     });
@@ -510,7 +472,7 @@ const Tokenize = (node) => {
                 default: {
                     //下划线内容等question/478154391/answer/121816724037
                     res.push({
-                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.PlainText,
+                        type: _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.PlainText,
                         text: child.textContent.replace(/\u200B/g, '').replace('\t', '').replace(/^\s{2,}/, ''),
                         dom: child,
                     });
@@ -522,20 +484,24 @@ const Tokenize = (node) => {
     return res;
 };
 
+/* harmony export */ __webpack_require__.d(__webpack_exports__, [
+/* harmony export */   "l", 0, /* binding */ lexer
+/* harmony export */ ]);
 
-/***/ }),
 
-/***/ 44:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ },
+
+/***/ 784
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   EE: () => (/* binding */ selectObsidianVault),
-/* harmony export */   KO: () => (/* binding */ hideObsidianModal),
-/* harmony export */   yH: () => (/* binding */ saveFile)
+/* harmony export */   OJ: () => (/* binding */ saveFile),
+/* harmony export */   XR: () => (/* binding */ hideObsidianModal),
+/* harmony export */   yY: () => (/* binding */ selectObsidianVault)
 /* harmony export */ });
 /* unused harmony exports showObsidianModal, saveObsidianConfig */
-/* harmony import */ var _toast__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(407);
+/* harmony import */ var _toast__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(197);
 
 // showToast('欢迎使用知乎助手-备份到obsidian插件');
 /**
@@ -1625,11 +1591,11 @@ async function saveFile(result, saveType) {
             const targetFolder = await finalHandle.getDirectoryHandle(folderName, { create: true });
             await unpackZipToFolder(result.zip, targetFolder);
             console.log(`成功解包ZIP文件到文件夹: ${folderName}`);
-            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .C)('✅ 保存成功');
+            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .P)('✅ 保存成功');
         }
         catch (error) {
             console.error('解包ZIP文件失败:', error);
-            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .C)('❌ 保存失败');
+            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .P)('❌ 保存失败');
             throw error;
         }
     }
@@ -1640,11 +1606,11 @@ async function saveFile(result, saveType) {
         try {
             await unpackZipCommon(result.zip, result.title, finalHandle);
             console.log(`成功共同解包ZIP文件: ${result.title}`);
-            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .C)('✅ 保存成功');
+            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .P)('✅ 保存成功');
         }
         catch (error) {
             console.error('共同解包ZIP文件失败:', error);
-            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .C)('❌ 保存失败');
+            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .P)('❌ 保存失败');
             throw error;
         }
     }
@@ -1660,11 +1626,11 @@ async function saveFile(result, saveType) {
             await writable.write(zipBlob);
             await writable.close();
             console.log(`成功保存ZIP文件: ${filename}`);
-            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .C)('✅ 保存成功');
+            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .P)('✅ 保存成功');
         }
         catch (error) {
             console.error('保存ZIP文件失败:', error);
-            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .C)('❌ 保存失败');
+            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .P)('❌ 保存失败');
             throw error;
         }
     }
@@ -1680,11 +1646,11 @@ async function saveFile(result, saveType) {
             await writable.write(blob);
             await writable.close();
             console.log(`成功保存图片文件: ${filename}`);
-            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .C)('✅ 保存成功');
+            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .P)('✅ 保存成功');
         }
         catch (error) {
             console.error('保存图片文件失败:', error);
-            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .C)('❌ 保存失败');
+            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .P)('❌ 保存失败');
             throw error;
         }
     }
@@ -1699,11 +1665,11 @@ async function saveFile(result, saveType) {
             await writable.write(result.textString);
             await writable.close();
             console.log(`成功保存MD文件: ${filename}`);
-            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .C)('✅ 保存成功');
+            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .P)('✅ 保存成功');
         }
         catch (error) {
             console.error('保存MD文件失败:', error);
-            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .C)('❌ 保存失败');
+            (0,_toast__WEBPACK_IMPORTED_MODULE_0__/* .showToast */ .P)('❌ 保存失败');
             throw error;
         }
     }
@@ -1768,16 +1734,13 @@ async function unpackZipCommon(zip, title, targetFolder, assetsFolder = 'assets'
 }
 
 
-/***/ }),
+/***/ },
 
-/***/ 940:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ 135
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   E: () => (/* binding */ parser)
-/* harmony export */ });
-/* harmony import */ var _tokenTypes__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(307);
+/* harmony import */ var _tokenTypes__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(278);
 
 /**
  * Parses an array of LexType objects and returns an array of strings representing the parsed output.
@@ -1789,51 +1752,51 @@ const parser = (input) => {
     for (let i = 0; i < input.length; i++) {
         const token = input[i];
         switch (token.type) {
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Code: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Code: {
                 output.push(`\`\`\`${token.language ? token.language : ""}\n${token.content}${token.content.endsWith("\n") ? "" : "\n"}\`\`\``);
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.UList: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.UList: {
                 output.push(token.content.map((item) => `- ${renderRich(item)}`).join("\n"));
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Olist: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Olist: {
                 output.push(token.content.map((item, index) => `${index + 1}. ${renderRich(item)}`).join("\n"));
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.H2: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.H2: {
                 output.push(`## ${token.text}`);
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.H3: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.H3: {
                 output.push(`### ${token.text}`);
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Blockquote: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Blockquote: {
                 output.push(renderRich(token.content, "> ").replace(/\n/g, '\n> \n')); // 修复部分引用不分段问题
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Text: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Text: {
                 output.push(renderRich(token.content));
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.HR: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.HR: {
                 output.push("\n---\n");
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Link: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Link: {
                 output.push(`[${token.text}](${token.href})`);
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Figure:
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Gif: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Figure:
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Gif: {
                 // @ts-ignore
                 window.no_save_img && !token.local ?
                     output.push(`[图片]`) :
                     output.push(`![](${token.local ? token.localSrc : token.src})`);
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Video: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Video: {
                 // 创建一个虚拟的 DOM 节点
                 const dom = document.createElement("video");
                 dom.setAttribute("src", token.local ? token.localSrc : token.src);
@@ -1842,7 +1805,7 @@ const parser = (input) => {
                 output.push(dom.outerHTML);
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Table: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Table: {
                 //console.log(token)
                 const rows = token.content;
                 const cols = rows[0].length;
@@ -1877,7 +1840,7 @@ const parser = (input) => {
                 output.push(res.join("\n"));
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.FootnoteList: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.FootnoteList: {
                 // 渲染脚注定义列表
                 const footnotes = token.items.map(item => `[^${item.id}]: ${item.content}`);
                 output.push(footnotes.join("\n"));
@@ -1897,31 +1860,31 @@ const renderRich = (input, joint = "") => {
     let res = "";
     for (let el of input) {
         switch (el.type) {
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Bold: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Bold: {
                 res += `**${renderRich(el.content)}** `; // 修复md阅读器识别带标点符号的加粗内容有误问题
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Italic: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Italic: {
                 res += `*${renderRich(el.content)}*`;
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.InlineLink: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.InlineLink: {
                 res += `[${el.text}](${el.href})`;
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.PlainText: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.PlainText: {
                 res += el.text;
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.BR: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.BR: {
                 res += "\n" + joint;
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.InlineCode: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.InlineCode: {
                 res += `\`${el.content}\``;
                 break;
             }
-            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .i.Math: {
+            case _tokenTypes__WEBPACK_IMPORTED_MODULE_0__/* .TokenType */ .k.Math: {
                 const mathToken = el;
                 if (mathToken.display) {
                     res += `\n\n$$\n${mathToken.content}\n$$\n\n`;
@@ -1937,24 +1900,28 @@ const renderRich = (input, joint = "") => {
     return joint + res;
 };
 
+/* harmony export */ __webpack_require__.d(__webpack_exports__, [
+/* harmony export */   "K", 0, /* binding */ parser
+/* harmony export */ ]);
 
-/***/ }),
 
-/***/ 546:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ },
+
+/***/ 188
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 
 // EXPORTS
 __webpack_require__.d(__webpack_exports__, {
-  Z: () => (/* binding */ savelex)
+  A: () => (/* binding */ savelex)
 });
 
-// EXTERNAL MODULE: ./node_modules/.pnpm/jszip@3.9.1/node_modules/jszip/dist/jszip.min.js
-var jszip_min = __webpack_require__(434);
+// EXTERNAL MODULE: ./node_modules/.pnpm/jszip@3.10.1/node_modules/jszip/dist/jszip.min.js
+var jszip_min = __webpack_require__(1);
 // EXTERNAL MODULE: ./src/core/tokenTypes.ts
-var tokenTypes = __webpack_require__(307);
-;// CONCATENATED MODULE: ./src/core/download2zip.ts
+var tokenTypes = __webpack_require__(278);
+;// ./src/core/download2zip.ts
 /**
  * 下载文件并将其添加到zip文件中
  * @param url 下载文件的URL
@@ -1982,7 +1949,7 @@ async function downloadAndZipAll(urls, zip) {
     return zip;
 }
 
-;// CONCATENATED MODULE: ./src/core/savelex.ts
+;// ./src/core/savelex.ts
 
 
 
@@ -1990,7 +1957,7 @@ async function downloadAndZipAll(urls, zip) {
     const zip = new jszip_min();
     let FigureFlag = false;
     for (let token of lex) {
-        if (token.type == tokenTypes/* TokenType */.i.Figure || token.type == tokenTypes/* TokenType */.i.Video || token.type == tokenTypes/* TokenType */.i.Gif) {
+        if (token.type == tokenTypes/* TokenType */.k.Figure || token.type == tokenTypes/* TokenType */.k.Video || token.type == tokenTypes/* TokenType */.k.Gif) {
             FigureFlag = true;
             break;
         }
@@ -2000,9 +1967,9 @@ async function downloadAndZipAll(urls, zip) {
         for (let token of lex) {
             try {
                 switch (token.type) {
-                    case tokenTypes/* TokenType */.i.Figure:
-                    case tokenTypes/* TokenType */.i.Video:
-                    case tokenTypes/* TokenType */.i.Gif: {
+                    case tokenTypes/* TokenType */.k.Figure:
+                    case tokenTypes/* TokenType */.k.Video:
+                    case tokenTypes/* TokenType */.k.Gif: {
                         const { file_name } = await downloadAndZip(token.src, assetsFolder);
                         token.localSrc = `./${assetsPath}/${file_name}`;
                         token.local = true;
@@ -2020,17 +1987,15 @@ async function downloadAndZipAll(urls, zip) {
     zip.file("index.md", markdown)*/
     return { zip: zip, localLex: lex };
 });
+__webpack_require__.dn(savelex);
 
 
-/***/ }),
+/***/ },
 
-/***/ 407:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ 197
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   C: () => (/* binding */ showToast)
-/* harmony export */ });
 // 维护活动的 toast 列表
 const activeToasts = [];
 const TOAST_HEIGHT = 60; // 每个 toast 的高度间隔
@@ -2122,15 +2087,19 @@ const updateToastPositions = () => {
     });
 };
 
+/* harmony export */ __webpack_require__.d(__webpack_exports__, [
+/* harmony export */   "P", 0, /* binding */ showToast
+/* harmony export */ ]);
 
-/***/ }),
 
-/***/ 307:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ },
+
+/***/ 278
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   i: () => (/* binding */ TokenType)
+/* harmony export */   k: () => (/* binding */ TokenType)
 /* harmony export */ });
 /**
  * Enum representing the different types of tokens in the parsed markdown.
@@ -2161,340 +2130,196 @@ var TokenType;
 })(TokenType || (TokenType = {}));
 
 
-/***/ }),
+/***/ },
 
-/***/ 465:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ 379
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   Au: () => (/* binding */ getAuthor),
-/* harmony export */   Ax: () => (/* binding */ getURL),
-/* harmony export */   YQ: () => (/* binding */ getTitle),
-/* harmony export */   hK: () => (/* binding */ getTime),
-/* harmony export */   iw: () => (/* binding */ getRemark),
-/* harmony export */   k$: () => (/* binding */ getLocation),
-/* harmony export */   ld: () => (/* binding */ ZhihuLink2NormalLink),
-/* harmony export */   og: () => (/* binding */ getCommentNum),
-/* harmony export */   vE: () => (/* binding */ getCommentSwitch),
-/* harmony export */   vb: () => (/* binding */ getUpvote)
-/* harmony export */ });
-/**
- * Converts a Zhihu link to a normal link.
- * @param link - The Zhihu link to convert.
- * @returns The converted normal link.
- */
 const ZhihuLink2NormalLink = (link) => {
-    const url = new URL(link);
-    if (url.hostname == "link.zhihu.com") {
-        const target = new URLSearchParams(url.search).get("target");
-        return decodeURIComponent(target);
-    }
-    else {
-        if (link.match(/#/))
-            return '#' + link.split('#')[1];
-        else
-            return link;
-    }
-};
-/**
- * Get the title of the dom.
- * @param dom - The dom to get title.
- * @returns The title of the dom.
- */
-const getTitle = (dom, scene, type) => {
-    let t;
-    if (scene == "follow" || scene == "people" || scene == "collection" || scene == "pin") {
-        let title_dom = dom.closest('.ContentItem').querySelector("h2.ContentItem-title a");
-        if (type == "answer" || type == "article") {
-            //搜索结果页最新讨论
-            !title_dom ? title_dom = dom.closest('.HotLanding-contentItem').querySelector("h2.ContentItem-title a") : 0;
-            t = title_dom.textContent;
-        }
-        else { //想法
-            if (title_dom) {
-                t = "想法：" + title_dom.textContent + '-' + dom.innerText.slice(0, 16).trim().replace(/\s/g, "");
-            }
-            else
-                t = "想法：" + dom.innerText.slice(0, 24).trim().replace(/\s/g, "");
-        }
-    }
-    //问题/回答
-    else if (scene == "question" || scene == "answer") {
-        t = dom.closest('.QuestionPage').querySelector("meta[itemprop=name]").content;
-    }
-    //文章
-    else if (scene == "article") {
-        t = dom.closest('.Post-Main').querySelector("h1.Post-Title").textContent;
-    }
-    else
-        t = "无标题";
-    //替换英文问号为中文问号，因标题中间也可能有问号所以不去掉
-    return t.replace(/\?/g, "？").replace(/\/|\\|<|>|"|\*|\?|\||\:/g, "-");
-};
-/**
- * Get the author of the dom.
- * @param dom - The dom to get author.
- * @returns The author of the dom.
- */
-const getAuthor = (dom, scene, type) => {
-    let author_dom;
-    //寻找包含昵称+链接+签名的节点
-    if (scene == "follow") {
-        let p = dom.closest('.ContentItem');
-        //唯独关注页作者在ContentItem外面，原创内容没有作者栏
-        author_dom = p.querySelector(".AuthorInfo-content") ||
-            dom.closest('.Feed').querySelector(".FeedSource .AuthorInfo-content") ||
-            dom.closest('.Feed').querySelector(".FeedSource-firstline");
-    }
-    ///个人/问题/回答/想法/收藏夹
-    else if (scene == "people" || scene == "question" || scene == "answer" || scene == "pin" || scene == "collection") {
-        let p = dom.closest('.ContentItem');
-        author_dom = p.querySelector(".AuthorInfo-content");
-        // 个人页的搜索结果的想法没有作者栏
-        if (!author_dom && location.href.includes('search')) {
-            author_dom = document.querySelector('.ProfileHeader-title');
-            return {
-                name: author_dom.children[0].textContent,
-                url: location.href.match(/(https.*)\/search/)[1],
-                badge: author_dom.children[1].textContent
-            };
-        }
-    }
-    //文章
-    else if (scene == "article") {
-        author_dom = dom.closest('.Post-Main').querySelector(".Post-Author");
-    }
-    if (author_dom) {
-        let authorName_dom = author_dom.querySelector(".AuthorInfo-name .UserLink-link") ||
-            author_dom.querySelector(".UserLink-link") ||
-            author_dom.querySelector(".UserLink.AuthorInfo-name"); //匿名用户
-        let authorBadge_dom = author_dom.querySelector(".AuthorInfo-badge");
-        //console.log("authorName_dom", authorName_dom)
-        return {
-            name: authorName_dom.innerText || (authorName_dom.children[0] ? authorName_dom.children[0].getAttribute("alt") : ''), //???//没有名字的用户https://www.zhihu.com/people/8-90-74/answers
-            url: authorName_dom.href,
-            badge: authorBadge_dom ? authorBadge_dom.innerText : ""
-        };
-    }
-    else
-        console.error("未找到author_dom");
-};
-/**
- * Get the URL of the dom.
- * 应该按每个内容获取URL，而非目前网址
- * @param dom - The dom to get URL.
- * @returns The URL of the dom.
- */
-const getURL = (dom, scene, type) => {
-    let url;
-    //文章/想法/回答
-    if (scene == "article" || scene == "pin" || scene == "answer") {
-        url = window.location.href;
-        let q = url.match(/\?/) ? url.match(/\?/).index : 0;
-        if (q)
-            url = url.slice(0, q);
-        return url;
-    }
-    //关注/个人/问题/等
-    // if (scene == "follow" || scene == "people" || scene == "question")
-    else {
-        if (type == "answer" || type == "article") {
-            //普通
-            let p = dom.closest('.ContentItem');
-            let url_dom = p.querySelector(".ContentItem>meta[itemprop=url]");
-            //搜索结果页
-            if (!url_dom) {
-                url_dom = p.querySelector(".ContentItem h2 a");
-            }
-            //搜索结果页最新讨论
-            if (!url_dom) {
-                p = dom.closest('.HotLanding-contentItem');
-                url_dom = p.querySelector(".ContentItem h2 a");
-            }
-            url = url_dom.content || (url_dom.href);
-            if (url.slice(0, 5) != "https")
-                url = "https:" + url;
-            return url;
-        }
-        //pin
-        else {
-            let zopdata = dom.closest('.ContentItem').getAttribute("data-zop");
-            return "https://www.zhihu.com/pin/" + JSON.parse(zopdata).itemId;
-        }
-    }
-};
-/**
- *
- * 时间：
- * 使用内容下显示的时间
- *
- */
-const getTime = async (dom, scene, type) => {
-    //关注/个人/问题/回答页
-    //if (scene == "follow" || scene == "people" || scene == "question" || scene == "answer") {//收藏夹
-    //  if (type != "" || type == "article") {
-    let created, modified, time_dom;
-    if (scene != "article") {
-        time_dom = dom.closest('.ContentItem').querySelector(".ContentItem-time");
-        created = time_dom.querySelector("a").getAttribute("data-tooltip").slice(4); //2023-12-30 16:12
-        modified = time_dom.querySelector("a").innerText.slice(4);
-        return { created, modified };
-    }
-    else { //文章
-        time_dom = dom.closest('.Post-content').querySelector(".ContentItem-time");
-        modified = time_dom.childNodes[0].textContent.slice(4);
-        time_dom.click();
-        await new Promise((resolve) => {
-            setTimeout(() => {
-                resolve();
-            }, 1000);
-        });
-        created = time_dom.childNodes[0].textContent.slice(4);
-        time_dom.click();
-        return { created, modified };
-    }
-    //  }
-    //}
-};
-const getUpvote = (dom, scene, type) => {
-    //关注/个人/问题/回答页
-    //if (scene == "follow" || scene == "people" || scene == "question" || scene == "answer") {//收藏夹
-    //up_dom = (getParent(dom, "ContentItem") as HTMLElement).querySelector(".VoteButton--up") as HTMLElement//\n赞同 5.6 万
-    let upvote, up_dom;
-    if (type == "pin") {
-        //个人页的想法有2层ContentItem-actions，想法页有1层
-        up_dom = dom.closest('.ContentItem').querySelector(".ContentItem-actions>.ContentItem-actions") ||
-            dom.closest('.ContentItem').querySelector(".ContentItem-actions");
-        up_dom = up_dom.childNodes[0];
-        upvote = up_dom.textContent.replace(/,|\u200B/g, '').slice(3); //0, -4
-        upvote ? 0 : upvote = 0;
-    }
-    else if (scene == "article") {
-        up_dom = dom.closest('.Post-content').querySelector(".ContentItem-actions .VoteButton");
-        upvote = up_dom.textContent.replace(/,|\u200B/g, '').slice(3);
-        upvote ? 0 : upvote = 0;
-    }
-    else {
-        let zaedata = dom.closest('.ContentItem').getAttribute("data-za-extra-module");
-        //搜索结果页
-        if (window.location.href.includes('/search?')) {
-            upvote = dom.closest('.RichContent').querySelector(".ContentItem-actions .VoteButton").getAttribute('aria-label').slice(3) || 0;
-        }
-        else
-            upvote = JSON.parse(zaedata).card.content.upvote_num;
-    }
-    return parseInt(upvote);
-    //  }
-    //}
-};
-const getCommentNum = (dom, scene, type) => {
-    //关注/个人/问题/回答页
-    //if (scene == "follow" || scene == "people" || scene == "question" || scene == "answer") {//收藏夹
-    let cm, cm_dom, p;
-    //被展开的评论区
-    p = dom.closest('.ContentItem');
-    p ? cm_dom = p.querySelector(".css-1k10w8f") : 0;
-    if (cm_dom) {
-        cm = cm_dom.textContent.replace(/,|\u200B/g, "").slice(0, -4);
-    }
-    else if (type == "pin") {
-        cm_dom = dom.closest('.ContentItem').querySelector(".ContentItem-actions>.ContentItem-actions") ||
-            dom.closest('.ContentItem').querySelector(".ContentItem-actions");
-        cm_dom = cm_dom.childNodes[1];
-        cm = cm_dom.textContent.replace(/,|\u200B/g, "").slice(0, -4);
-        cm ? 0 : cm = 0;
-    }
-    else if (scene == "article") {
-        cm_dom = dom.closest('.Post-content').querySelector(".BottomActions-CommentBtn");
-        cm = cm_dom.textContent.replace(/,|\u200B/g, '').slice(0, -4);
-        cm ? 0 : cm = 0;
-    }
-    else {
-        let zaedata = dom.closest('.ContentItem').getAttribute("data-za-extra-module");
-        //搜索结果页
-        if (window.location.href.includes('/search?')) {
-            cm_dom = dom.closest('.RichContent').querySelector("button.ContentItem-action");
-            cm = cm_dom.textContent.replace(/,|\u200B/g, "").slice(0, -4);
-        }
-        else
-            cm = JSON.parse(zaedata).card.content.comment_num;
-    }
-    return parseInt(cm);
-    //  }
-    //}
-};
-const getRemark = (dom) => {
-    let remark, p = dom.closest('.ContentItem'); //文章页没有，remark = remark.replace(/\/|\\|<|>|"|\*|\?|\||\:/g, "-")
-    if (!p)
-        p = dom.closest('.PinItem');
-    if (!p)
-        p = dom.closest('.Post-content');
-    if (p)
-        remark = p.querySelector("textarea.to-remark").value.replace(/\s/g, "-");
-    if (remark.match(/\/|\\|<|>|"|\*|\?|\||\:/g))
-        return "非法备注";
-    return remark;
-};
-/**
- * 获取是否需要保存评论，用于截图，zip
- */
-const getCommentSwitch = (dom) => {
-    let s, p = dom.closest('.ContentItem');
-    if (!p)
-        p = dom.closest('.PinItem');
-    if (!p)
-        p = dom.closest('.Post-content');
-    if (p)
-        s = p.querySelector("input.to-cm").checked;
-    return s;
-};
-/**
- * Get the Location of the dom.
- * @param dom - The dom.
- * @returns string | null
- */
-const getLocation = (dom, scene, type) => {
-    let location, el = dom.closest('.ContentItem'); //想法类型、文章页没有
-    if (!el)
-        el = dom.closest('.PinItem');
-    if (!el)
-        el = dom.closest('.Post-content');
     try {
-        if (el) {
-            location = el.querySelector('.ContentItem-time').childNodes[1]?.textContent.slice(6);
+        const url = new URL(link);
+        if (url.hostname == "link.zhihu.com") {
+            const target = new URLSearchParams(url.search).get("target");
+            return decodeURIComponent(target || "");
         }
-        if (!location && scene == "people") {
-            let name = document.querySelector('.ProfileHeader-name').childNodes[0].textContent;
-            if (name == getAuthor(dom, scene, type).name) {
-                location = document.querySelector('.css-1xfvezd').textContent.slice(5);
-            }
+        else {
+            if (link.match(/#/))
+                return '#' + link.split('#')[1];
+            else
+                return link;
         }
     }
     catch (e) {
-        console.error('保存location出错', e);
+        return link;
     }
-    return location;
+};
+const getTitle = (dom, scene, type) => {
+    try {
+        // 1. Check Question Page (Answer pages like /question/123/answer/456)
+        const qPage = dom.closest('.QuestionPage') || document.querySelector('.QuestionPage');
+        if (qPage) {
+            const metaName = qPage.querySelector('meta[itemprop=name]');
+            if (metaName && metaName.content) {
+                return metaName.content.trim().replace(/\?/g, "？").replace(/\/|\\|<|>|"|\*|\||\:/g, "-");
+            }
+            const qTitle = qPage.querySelector('.QuestionHeader-title, h1.QuestionHeader-title');
+            if (qTitle && qTitle.innerText) {
+                return qTitle.innerText.trim().replace(/\?/g, "？").replace(/\/|\\|<|>|"|\*|\||\:/g, "-");
+            }
+        }
+        // 2. Check Answer/Article Item in Feed/Lists/Collections
+        const item = dom.closest('.AnswerItem') || dom.closest('.ArticleItem') || dom.closest('.ContentItem') || dom.closest('.Card');
+        if (item) {
+            const titleEl = item.querySelector('h2.ContentItem-title a, .ContentItem-title a, h2.ContentItem-title');
+            if (titleEl && titleEl.innerText) {
+                return titleEl.innerText.trim().replace(/\?/g, "？").replace(/\/|\\|<|>|"|\*|\||\:/g, "-");
+            }
+        }
+        // 3. Check Zhuanlan Post/Article
+        const postMain = dom.closest('.Post-Main') || document.querySelector('.Post-Main');
+        if (postMain) {
+            const postTitle = postMain.querySelector('h1.Post-Title');
+            if (postTitle && postTitle.innerText) {
+                return postTitle.innerText.trim().replace(/\?/g, "？").replace(/\/|\\|<|>|"|\*|\||\:/g, "-");
+            }
+        }
+        // 4. Global Meta & H1 Fallback
+        const globalMeta = document.querySelector('meta[itemprop=name]');
+        if (globalMeta && globalMeta.content) {
+            return globalMeta.content.trim().replace(/\?/g, "？").replace(/\/|\\|<|>|"|\*|\||\:/g, "-");
+        }
+        const globalH1 = document.querySelector('h1.QuestionHeader-title, h1.Post-Title');
+        if (globalH1 && globalH1.innerText) {
+            return globalH1.innerText.trim().replace(/\?/g, "？").replace(/\/|\\|<|>|"|\*|\||\:/g, "-");
+        }
+    }
+    catch (e) { }
+    return "无标题";
+};
+const getAuthor = (dom, scene, type) => {
+    try {
+        let item = dom.closest('.ContentItem') || dom.closest('.Post-Main') || dom.closest('.PinItem') || dom;
+        if (item) {
+            let authorName_dom = item.querySelector(".AuthorInfo-name .UserLink-link, .UserLink-link, .AuthorInfo-name");
+            let authorBadge_dom = item.querySelector(".AuthorInfo-badge, .AuthorInfo-badgeText");
+            if (authorName_dom) {
+                let href = authorName_dom.href || "";
+                let name = authorName_dom.innerText || (authorName_dom.children[0] ? authorName_dom.children[0].getAttribute("alt") || "" : "");
+                return {
+                    name: name.trim() || "匿名用户",
+                    url: href,
+                    badge: authorBadge_dom ? authorBadge_dom.innerText.trim() : ""
+                };
+            }
+        }
+    }
+    catch (e) { }
+    return { name: "匿名用户", url: "", badge: "" };
+};
+const getURL = (dom, scene, type) => {
+    try {
+        if (window.location.pathname === "/") {
+            let item = dom.closest('.ContentItem') || dom.closest('.AnswerItem') || dom.closest('.ArticleItem');
+            if (item) {
+                let a = item.querySelector("a[data-za-detail-view-id]");
+                if (a && a.href)
+                    return a.href;
+            }
+        }
+    }
+    catch (e) { }
+    return window.location.origin + window.location.pathname;
+};
+const getTime = async (dom, scene) => {
+    try {
+        let item = dom.closest('.ContentItem') || dom.closest('.Post-content') || dom.closest('.PinItem') || dom;
+        let timeEl = item.querySelector('.ContentItem-time, .Post-Time, .PinItem-time, .ContentItem-status');
+        if (timeEl) {
+            let text = timeEl.innerText.replace(/\s+/g, ' ').trim();
+            return { created: text, modified: text };
+        }
+    }
+    catch (e) { }
+    return { created: "", modified: "" };
+};
+const getUpvote = (dom, scene, type) => {
+    try {
+        let item = dom.closest('.ContentItem') || dom.closest('.Post-content') || dom.closest('.PinItem') || dom;
+        let up = item.querySelector('.VoteButton--up, .AnswerItem-extraInfo, button[aria-label*="赞同"]');
+        if (up)
+            return up.innerText.replace(/\s+/g, ' ').trim();
+    }
+    catch (e) { }
+    return "";
+};
+const getCommentNum = (dom, scene, type) => {
+    try {
+        let item = dom.closest('.ContentItem') || dom.closest('.Post-content') || dom;
+        let btn = item.querySelector('.ContentItem-actions button:has(.Zi--comment)');
+        if (btn)
+            return btn.textContent || "";
+    }
+    catch (e) { }
+    return "";
+};
+const getRemark = (dom) => {
+    try {
+        let wrap = dom.closest('.zhihubackup-wrap') || dom.closest('.zhcollect-minimal-btns');
+        if (wrap) {
+            let ta = wrap.querySelector('.to-remark');
+            if (ta)
+                return ta.value;
+        }
+    }
+    catch (e) { }
+    return "";
+};
+const getCommentSwitch = (dom) => {
+    try {
+        let wrap = dom.closest('.zhihubackup-wrap');
+        if (wrap) {
+            let cb = wrap.querySelector('.to-cm');
+            if (cb)
+                return cb.checked;
+        }
+    }
+    catch (e) { }
+    return false;
+};
+const getLocation = (dom, scene, type) => {
+    return "";
 };
 
+/* harmony export */ __webpack_require__.d(__webpack_exports__, [
+/* harmony export */   "AP", 0, /* binding */ getURL,
+/* harmony export */   "IQ", 0, /* binding */ ZhihuLink2NormalLink,
+/* harmony export */   "LK", 0, /* binding */ getTitle,
+/* harmony export */   "P_", 0, /* binding */ getRemark,
+/* harmony export */   "UR", 0, /* binding */ getCommentNum,
+/* harmony export */   "WB", 0, /* binding */ getTime,
+/* harmony export */   "aJ", 0, /* binding */ getUpvote,
+/* harmony export */   "g$", 0, /* binding */ getLocation,
+/* harmony export */   "kn", 0, /* binding */ getAuthor,
+/* harmony export */   "mK", 0, /* binding */ getCommentSwitch
+/* harmony export */ ]);
 
-/***/ }),
 
-/***/ 250:
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+/***/ },
+
+/***/ 331
+(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   Z: () => (__WEBPACK_DEFAULT_EXPORT__)
-/* harmony export */ });
-/* harmony import */ var _core_lexer__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(108);
-/* harmony import */ var _core_tokenTypes__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(307);
-/* harmony import */ var _core_parser__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(940);
-/* harmony import */ var _core_utils__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(465);
-/* harmony import */ var _core_savelex__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(546);
-/* harmony import */ var _core_renderComments__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(385);
-/* harmony import */ var _core_toast__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(407);
-/* harmony import */ var _core_obsidianSaver__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(44);
+/* unused harmony export getHeaderMarkdown */
+/* harmony import */ var _core_lexer__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(236);
+/* harmony import */ var _core_tokenTypes__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(278);
+/* harmony import */ var _core_parser__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(135);
+/* harmony import */ var _core_utils__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(379);
+/* harmony import */ var _core_savelex__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(188);
+/* harmony import */ var _core_renderComments__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(615);
+/* harmony import */ var _core_toast__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(197);
+/* harmony import */ var _core_obsidianSaver__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(784);
 
 
 
@@ -2532,38 +2357,52 @@ function detectScene() {
     return scene;
 }
 function detectType(dom, bt, ev) {
-    //ContentItem
-    let type;
     if (dom.closest('.AnswerItem'))
-        type = "answer";
-    else if (dom.closest('.ArticleItem'))
-        type = "article";
-    else if (dom.closest('.Post-content'))
-        type = "article";
-    else if (dom.closest('.PinItem'))
-        type = "pin";
-    else {
-        console.log("未知内容");
-        if (!ev) {
-            alert('请勿收起又展开内容，否则会保存失败。请手动重新保存。');
-        }
-        else {
-            let zhw = ev.target.closest('.zhihubackup-wrap'), bz = zhw.querySelector('textarea').value, fa = zhw.closest('.ContentItem') || zhw.closest('.Post-content') || zhw.closest('.HotLanding-contentItem');
-            !fa ? alert('请勿收起又展开内容，否则会保存失败。请重新保存。') : 0;
-            setTimeout(() => {
-                fa.querySelector('textarea').value = bz;
-            }, 200);
-            setTimeout(() => {
-                fa.querySelector(`.to-${bt}`).click();
-            }, 250);
-        }
-        document.querySelectorAll('.zhihubackup-wrap').forEach((w) => w.remove());
-        // @ts-ignore
-        setTimeout(window.zhbf, 100);
-        return;
-    }
-    return type;
+        return "answer";
+    if (dom.closest('.ArticleItem') || dom.closest('.Post-content') || dom.closest('.Post-Main'))
+        return "article";
+    if (dom.closest('.PinItem'))
+        return "pin";
+    if (dom.closest('.ContentItem'))
+        return "answer";
+    return "answer";
 }
+const getHeaderMarkdown = (dom, scene, type) => {
+    const title = (0,_core_utils__WEBPACK_IMPORTED_MODULE_3__/* .getTitle */ .LK)(dom, scene, type);
+    const url = (0,_core_utils__WEBPACK_IMPORTED_MODULE_3__/* .getURL */ .AP)(dom, scene, type);
+    const author = (0,_core_utils__WEBPACK_IMPORTED_MODULE_3__/* .getAuthor */ .kn)(dom, scene, type);
+    const upvote = (0,_core_utils__WEBPACK_IMPORTED_MODULE_3__/* .getUpvote */ .aJ)(dom, scene, type);
+    let item = dom.closest('.ContentItem') || dom.closest('.Post-content') || dom.closest('.PinItem') || dom;
+    let timeText = "";
+    if (item) {
+        let timeEl = item.querySelector('.ContentItem-time, .Post-Time, .PinItem-time, .ContentItem-status');
+        if (timeEl)
+            timeText = timeEl.innerText.replace(/\s+/g, ' ').trim();
+    }
+    let lines = [];
+    if (title && title !== "无标题") {
+        lines.push(`# ${title}\n`);
+    }
+    if (url && !url.includes("#WARNING")) {
+        lines.push(`> **原文链接**：[${url}](${url})`);
+    }
+    if (author && author.name) {
+        let authorStr = author.url ? `[${author.name}](${author.url})` : author.name;
+        if (author.badge)
+            authorStr += ` (${author.badge})`;
+        lines.push(`> **作者**：${authorStr}`);
+    }
+    if (timeText) {
+        lines.push(`> **时间**：${timeText}`);
+    }
+    if (upvote) {
+        lines.push(`> **赞同数**：${upvote}`);
+    }
+    if (lines.length > 0) {
+        return lines.join("\n") + "\n\n---\n\n";
+    }
+    return "";
+};
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (async (dom, button, event) => {
     //console.log(dom)
     //确认场景
@@ -2582,10 +2421,10 @@ function detectType(dom, bt, ev) {
             script.name
         } catch (e) {
         } */
-    (0,_core_toast__WEBPACK_IMPORTED_MODULE_5__/* .showToast */ .C)('✅ 开始保存');
-    const title = (0,_core_utils__WEBPACK_IMPORTED_MODULE_6__/* .getTitle */ .YQ)(dom, scene, type), author = (0,_core_utils__WEBPACK_IMPORTED_MODULE_6__/* .getAuthor */ .Au)(dom, scene, type), time = await (0,_core_utils__WEBPACK_IMPORTED_MODULE_6__/* .getTime */ .hK)(dom, scene), //?????????
-    url = (0,_core_utils__WEBPACK_IMPORTED_MODULE_6__/* .getURL */ .Ax)(dom, scene, type), upvote_num = (0,_core_utils__WEBPACK_IMPORTED_MODULE_6__/* .getUpvote */ .vb)(dom, scene, type), comment_num = (0,_core_utils__WEBPACK_IMPORTED_MODULE_6__/* .getCommentNum */ .og)(dom, scene, type), Location = (0,_core_utils__WEBPACK_IMPORTED_MODULE_6__/* .getLocation */ .k$)(dom, scene, type);
-    let remark = (0,_core_utils__WEBPACK_IMPORTED_MODULE_6__/* .getRemark */ .iw)(dom);
+    (0,_core_toast__WEBPACK_IMPORTED_MODULE_6__/* .showToast */ .P)('✅ 开始保存');
+    const title = (0,_core_utils__WEBPACK_IMPORTED_MODULE_3__/* .getTitle */ .LK)(dom, scene, type), author = (0,_core_utils__WEBPACK_IMPORTED_MODULE_3__/* .getAuthor */ .kn)(dom, scene, type), time = await (0,_core_utils__WEBPACK_IMPORTED_MODULE_3__/* .getTime */ .WB)(dom, scene), //?????????
+    url = (0,_core_utils__WEBPACK_IMPORTED_MODULE_3__/* .getURL */ .AP)(dom, scene, type), upvote_num = (0,_core_utils__WEBPACK_IMPORTED_MODULE_3__/* .getUpvote */ .aJ)(dom, scene, type), comment_num = (0,_core_utils__WEBPACK_IMPORTED_MODULE_3__/* .getCommentNum */ .UR)(dom, scene, type), Location = (0,_core_utils__WEBPACK_IMPORTED_MODULE_3__/* .getLocation */ .g$)(dom, scene, type);
+    let remark = (0,_core_utils__WEBPACK_IMPORTED_MODULE_3__/* .getRemark */ .P_)(dom);
     if (remark === "非法备注") {
         alert(decodeURIComponent("备注不可包含%20%20%2F%20%3A%20*%20%3F%20%22%20%3C%20%3E%20%7C"));
         return;
@@ -2661,7 +2500,7 @@ function detectType(dom, bt, ev) {
      * 生成目录
      */
     const TOC = (() => {
-        let toc = (dom.closest('.ContentItem') || dom.closest('.Post-content')).querySelector(".Catalog-content");
+        let toc = (dom.closest('.ContentItem') || dom.closest('.Post-content'))?.querySelector(".Catalog-content");
         let items = [];
         if (toc) {
             let i = 1, j = 1;
@@ -2679,7 +2518,7 @@ function detectType(dom, bt, ev) {
         else
             return null;
     })();
-    const lex = (0,_core_lexer__WEBPACK_IMPORTED_MODULE_0__/* .lexer */ .c)(dom.childNodes, type);
+    const lex = (0,_core_lexer__WEBPACK_IMPORTED_MODULE_0__/* .lexer */ .l)(dom.childNodes, type);
     var md = [], originPinMD = [];
     //console.log("lex", lex)
     //保存文章头图
@@ -2688,35 +2527,35 @@ function detectType(dom, bt, ev) {
         const src = headImg.getAttribute("src");
         if (src)
             lex.unshift({
-                type: _core_tokenTypes__WEBPACK_IMPORTED_MODULE_1__/* .TokenType */ .i.Figure,
+                type: _core_tokenTypes__WEBPACK_IMPORTED_MODULE_1__/* .TokenType */ .k.Figure,
                 src,
                 local: false,
                 dom: headImg
             });
     }
     //是转发的想法，对源想法解析，并准备附加到新想法下面
-    if (type == "pin" && dom.closest('.PinItem').querySelector(".PinItem-content-originpin")) {
-        const dom2 = dom.closest('.PinItem').querySelector(".PinItem-content-originpin .RichText");
-        const lex2 = (0,_core_lexer__WEBPACK_IMPORTED_MODULE_0__/* .lexer */ .c)(dom2.childNodes, type);
+    if (type == "pin" && dom.closest('.PinItem')?.querySelector(".PinItem-content-originpin")) {
+        const dom2 = dom.closest('.PinItem')?.querySelector(".PinItem-content-originpin .RichText");
+        const lex2 = (0,_core_lexer__WEBPACK_IMPORTED_MODULE_0__/* .lexer */ .l)(dom2.childNodes, type);
         //markdown = markdown.concat(parser(lex2).map((l) => "> " + l))
-        originPinMD.push('\n\n' + (0,_core_parser__WEBPACK_IMPORTED_MODULE_2__/* .parser */ .E)(lex2).map((l) => "> " + l).join("\n> \n"));
+        originPinMD.push('\n\n' + (0,_core_parser__WEBPACK_IMPORTED_MODULE_2__/* .parser */ .K)(lex2).map((l) => "> " + l).join("\n> \n"));
     }
     // 获取想法图片/标题
     if (type == "pin") {
         const pinItem = dom.closest('.PinItem');
-        if (pinItem.querySelector(".ContentItem-title"))
+        if (pinItem?.querySelector(".ContentItem-title"))
             lex.unshift({
-                type: _core_tokenTypes__WEBPACK_IMPORTED_MODULE_1__/* .TokenType */ .i.Text,
+                type: _core_tokenTypes__WEBPACK_IMPORTED_MODULE_1__/* .TokenType */ .k.Text,
                 content: [{
-                        type: _core_tokenTypes__WEBPACK_IMPORTED_MODULE_1__/* .TokenType */ .i.PlainText,
-                        text: '**' + pinItem.querySelector(".ContentItem-title").textContent + '**'
+                        type: _core_tokenTypes__WEBPACK_IMPORTED_MODULE_1__/* .TokenType */ .k.PlainText,
+                        text: '**' + (pinItem.querySelector(".ContentItem-title")?.textContent || '') + '**'
                     }]
             });
-        if (pinItem.querySelector(".PinItem-remainContentRichText")) {
-            const imgs = pinItem.querySelectorAll(".PinItem-remainContentRichText img");
+        if (pinItem?.querySelector(".PinItem-remainContentRichText")) {
+            const imgs = pinItem?.querySelectorAll(".PinItem-remainContentRichText img") || [];
             imgs.forEach((img) => {
                 lex.push({
-                    type: _core_tokenTypes__WEBPACK_IMPORTED_MODULE_1__/* .TokenType */ .i.Figure,
+                    type: _core_tokenTypes__WEBPACK_IMPORTED_MODULE_1__/* .TokenType */ .k.Figure,
                     src: img.getAttribute("data-original") || img.getAttribute("data-actualsrc"),
                 });
             });
@@ -2726,20 +2565,20 @@ function detectType(dom, bt, ev) {
     let commentText = '', commentsImgs = [];
     const dealComments = async () => {
         try {
-            if ((0,_core_utils__WEBPACK_IMPORTED_MODULE_6__/* .getCommentSwitch */ .vE)(dom)) {
+            if ((0,_core_utils__WEBPACK_IMPORTED_MODULE_3__/* .getCommentSwitch */ .mK)(dom)) {
                 let p = dom.closest('.ContentItem') || dom.closest('.Post-content');
-                let openComment = p.querySelector(".Comments-container");
+                let openComment = p?.querySelector(".Comments-container");
                 let itemId = type + url.split('/').pop();
                 let tip = '';
-                if (openComment && openComment.querySelector('.css-189h5o3')) {
-                    let t = '**' + openComment.querySelector('.css-189h5o3').textContent + '**'; //评论区已关闭|暂无评论
+                if (openComment && openComment?.querySelector('.css-189h5o3')) {
+                    let t = '**' + (openComment.querySelector('.css-189h5o3')?.textContent || '') + '**'; //评论区已关闭|暂无评论
                     if (button == 'text')
                         commentText = t;
                     else
                         zip.file("comments.md", t);
                 }
                 else {
-                    if (openComment && openComment.querySelector('.css-1tdhe7b'))
+                    if (openComment && openComment?.querySelector('.css-1tdhe7b'))
                         tip = '**评论内容由作者筛选后展示**\n\n';
                     // @ts-ignore 
                     let commentsData = window.ArticleComments[itemId]?.comments;
@@ -2750,9 +2589,9 @@ function detectType(dom, bt, ev) {
                         let obsidian = document.querySelector("#zhihu-obsidian-modal");
                         let display = obsidian?.style.display;
                         if (!s) {
-                            (0,_core_toast__WEBPACK_IMPORTED_MODULE_5__/* .showToast */ .C)('❎ 取消保存');
+                            (0,_core_toast__WEBPACK_IMPORTED_MODULE_6__/* .showToast */ .P)('❎ 取消保存');
                             if (display == "block") {
-                                (0,_core_obsidianSaver__WEBPACK_IMPORTED_MODULE_4__/* .hideObsidianModal */ .KO)();
+                                (0,_core_obsidianSaver__WEBPACK_IMPORTED_MODULE_7__/* .hideObsidianModal */ .XR)();
                             }
                             return 'return';
                         }
@@ -2760,11 +2599,11 @@ function detectType(dom, bt, ev) {
                             openComment.querySelector('.save').click();
                             setTimeout(() => {
                                 if (display == "block") {
-                                    (0,_core_toast__WEBPACK_IMPORTED_MODULE_5__/* .showToast */ .C)('❎ 取消保存');
-                                    (0,_core_obsidianSaver__WEBPACK_IMPORTED_MODULE_4__/* .hideObsidianModal */ .KO)();
+                                    (0,_core_toast__WEBPACK_IMPORTED_MODULE_6__/* .showToast */ .P)('❎ 取消保存');
+                                    (0,_core_obsidianSaver__WEBPACK_IMPORTED_MODULE_7__/* .hideObsidianModal */ .XR)();
                                     return alert('已【暂存此页评论】，由于这次是自定义文件夹保存，请再次手动保存文件。');
                                 }
-                                p.querySelector(`.zhihubackup-wrap .to-${button}`).click();
+                                p?.querySelector(`.zhihubackup-wrap .to-${button}, .zhcollect-minimal-btns .to-${button}`)?.click();
                             }, 1900);
                             return 'return';
                         }
@@ -2772,11 +2611,11 @@ function detectType(dom, bt, ev) {
                     let num_text = tip + '共 ' + comment_num + ' 条评论，已存 ' + commentsData.size + ' 条' + '\n\n';
                     if (button == 'text' || button == 'copy') {
                         // 准备添加第三种图片归宿，完全舍弃
-                        [commentText, commentsImgs] = (0,_core_renderComments__WEBPACK_IMPORTED_MODULE_7__/* .renderAllComments */ .L)(commentsData, false);
+                        [commentText, commentsImgs] = (0,_core_renderComments__WEBPACK_IMPORTED_MODULE_5__/* .renderAllComments */ .Y)(commentsData, false);
                         commentText = num_text + commentText;
                     }
                     else if (button == 'zip') {
-                        [commentText, commentsImgs] = (0,_core_renderComments__WEBPACK_IMPORTED_MODULE_7__/* .renderAllComments */ .L)(commentsData, true);
+                        [commentText, commentsImgs] = (0,_core_renderComments__WEBPACK_IMPORTED_MODULE_5__/* .renderAllComments */ .Y)(commentsData, true);
                         commentText = num_text + commentText;
                         if (commentsImgs.length) {
                             const assetsFolder = zip.folder('assets');
@@ -2796,7 +2635,15 @@ function detectType(dom, bt, ev) {
             alert('主要工作已完成，但是评论保存出错了');
         }
     };
-    if (button == 'copy') {
+    if (button == 'copy' || button == 'copy_context' || button == 'copy_content') {
+        let includeContext = button == 'copy_context';
+        if (button == 'copy' || button == 'copy_context' || button == 'copy_content') {
+            try {
+                // @ts-ignore
+                includeContext = GM_getValue("copy_save_title", true);
+            }
+            catch (e) { }
+        }
         try {
             // @ts-ignore
             var copy_save_fm = GM_getValue("copy_save_fm"), 
@@ -2806,8 +2653,8 @@ function detectType(dom, bt, ev) {
         catch (e) {
             console.warn(e);
         }
-        md = TOC ? TOC.concat((0,_core_parser__WEBPACK_IMPORTED_MODULE_2__/* .parser */ .E)(lex)) : (0,_core_parser__WEBPACK_IMPORTED_MODULE_2__/* .parser */ .E)(lex);
-        if (type == "pin" && dom.closest('.PinItem').querySelector(".PinItem-content-originpin")) {
+        md = TOC ? TOC.concat((0,_core_parser__WEBPACK_IMPORTED_MODULE_2__/* .parser */ .K)(lex)) : (0,_core_parser__WEBPACK_IMPORTED_MODULE_2__/* .parser */ .K)(lex);
+        if (type == "pin" && dom.closest('.PinItem')?.querySelector(".PinItem-content-originpin")) {
             md = md.concat(originPinMD); //解决保存转发的想法异常
         }
         if (copy_save_fm) {
@@ -2819,10 +2666,14 @@ function detectType(dom, bt, ev) {
             commentText ? commentText = '\n\n---\n\n## 评论\n\n' + commentText : 0;
             md.push(commentText);
         }
-        if (type != 'pin' && !copy_save_fm)
-            return { textString: [title].concat(md).join('\n\n') }; //复制内容增加标题
-        else
-            return { textString: md.join('\n\n') };
+        let bodyText = md.join('\n\n');
+        if (button === 'copy_context') {
+            let header = getHeaderMarkdown(dom, scene, type);
+            return { textString: header + bodyText };
+        }
+        else {
+            return { textString: bodyText };
+        }
     }
     // ============================以下只有 text 或 zip 2种情况===========================
     if (button == 'text') {
@@ -2830,24 +2681,24 @@ function detectType(dom, bt, ev) {
             return;
         commentText ? commentText = '\n\n---\n\n## 评论\n\n' + commentText : 0;
         let md2 = [];
-        if (type == "pin" && dom.closest('.PinItem').querySelector(".PinItem-content-originpin")) {
+        if (type == "pin" && dom.closest('.PinItem')?.querySelector(".PinItem-content-originpin")) {
             md2 = originPinMD;
         }
         return {
-            textString: getFrontmatter() + (TOC ? TOC.join("\n\n") + '\n\n' : '') + (0,_core_parser__WEBPACK_IMPORTED_MODULE_2__/* .parser */ .E)(lex).join("\n\n") + md2.join("\n\n") + commentText,
+            textString: getFrontmatter() + (TOC ? TOC.join("\n\n") + '\n\n' : '') + (0,_core_parser__WEBPACK_IMPORTED_MODULE_2__/* .parser */ .K)(lex).join("\n\n") + md2.join("\n\n") + commentText,
             title: getFilename()
         };
     }
     if (button == 'zip') {
         //对lex的再处理，保存资产，并将lex中链接改为本地
-        var { zip, localLex } = await (0,_core_savelex__WEBPACK_IMPORTED_MODULE_3__/* ["default"] */ .Z)(lex);
+        var { zip, localLex } = await (0,_core_savelex__WEBPACK_IMPORTED_MODULE_4__/* ["default"] */ .A)(lex);
         if (await dealComments() == 'return')
             return;
-        if (type == "pin" && dom.closest('.PinItem').querySelector(".PinItem-content-originpin")) {
-            md = (0,_core_parser__WEBPACK_IMPORTED_MODULE_2__/* .parser */ .E)(localLex).concat(md);
+        if (type == "pin" && dom.closest('.PinItem')?.querySelector(".PinItem-content-originpin")) {
+            md = (0,_core_parser__WEBPACK_IMPORTED_MODULE_2__/* .parser */ .K)(localLex).concat(md);
         }
         else
-            md = (0,_core_parser__WEBPACK_IMPORTED_MODULE_2__/* .parser */ .E)(localLex);
+            md = (0,_core_parser__WEBPACK_IMPORTED_MODULE_2__/* .parser */ .K)(localLex);
         try {
             // @ts-ignore
             var zip_merge_cm = GM_getValue("zip_merge_cm");
@@ -2875,16 +2726,21 @@ function detectType(dom, bt, ev) {
         title: getFilename()
     };
 });
+__webpack_require__.dn(__WEBPACK_DEFAULT_EXPORT__);
+
+/* harmony export */ __webpack_require__.d(__webpack_exports__, [
+/* harmony export */   "A", 0, /* export default binding */ __WEBPACK_DEFAULT_EXPORT__
+/* harmony export */ ]);
 
 
-/***/ }),
+/***/ },
 
-/***/ 385:
-/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+/***/ 615
+(__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   L: () => (/* binding */ renderAllComments)
+/* harmony export */   Y: () => (/* binding */ renderAllComments)
 /* harmony export */ });
 /**
  * 渲染单条评论
@@ -2971,29 +2827,29 @@ function renderAllComments(commentsMap, isLocalImg) {
 const [markdown, imgs] = renderAllComments(comments, true);
 console.log(markdown, imgs);*/
 
-/***/ })
+/***/ }
 
 /******/ 	});
 /************************************************************************/
 /******/ 	// The module cache
-/******/ 	var __webpack_module_cache__ = {};
+/******/ 	const __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
 /******/ 	function __webpack_require__(moduleId) {
 /******/ 		// Check if module is in cache
-/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		const cachedModule = __webpack_module_cache__[moduleId];
 /******/ 		if (cachedModule !== undefined) {
 /******/ 			return cachedModule.exports;
 /******/ 		}
 /******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 		const module = __webpack_module_cache__[moduleId] = {
 /******/ 			// no module.id needed
 /******/ 			// no module.loaded needed
 /******/ 			exports: {}
 /******/ 		};
 /******/ 	
 /******/ 		// Execute the module function
-/******/ 		__webpack_modules__[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
 /******/ 	
 /******/ 		// Return the exports of the module
 /******/ 		return module.exports;
@@ -3002,11 +2858,26 @@ console.log(markdown, imgs);*/
 /************************************************************************/
 /******/ 	/* webpack/runtime/define property getters */
 /******/ 	(() => {
-/******/ 		// define getter functions for harmony exports
+/******/ 		// define getter/value functions for harmony exports
 /******/ 		__webpack_require__.d = (exports, definition) => {
-/******/ 			for(var key in definition) {
-/******/ 				if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
-/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			if(Array.isArray(definition)) {
+/******/ 				var i = 0;
+/******/ 				while(i < definition.length) {
+/******/ 					var key = definition[i++];
+/******/ 					var binding = definition[i++];
+/******/ 					if(!__webpack_require__.o(exports, key)) {
+/******/ 						if(binding === 0) {
+/******/ 							Object.defineProperty(exports, key, { enumerable: true, value: definition[i++] });
+/******/ 						} else {
+/******/ 							Object.defineProperty(exports, key, { enumerable: true, get: binding });
+/******/ 						}
+/******/ 					} else if(binding === 0) { i++; }
+/******/ 				}
+/******/ 			} else {
+/******/ 				for(var key in definition) {
+/******/ 					if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 						Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 					}
 /******/ 				}
 /******/ 			}
 /******/ 		};
@@ -3029,1094 +2900,1704 @@ console.log(markdown, imgs);*/
 /******/ 		__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
 /******/ 	})();
 /******/ 	
+/******/ 	/* webpack/runtime/set anonymous default export name */
+/******/ 	(() => {
+/******/ 		// set .name for anonymous default exports per ES spec
+/******/ 		__webpack_require__.dn = (x) => {
+/******/ 			(Object.getOwnPropertyDescriptor(x, "name") || {}).writable || Object.defineProperty(x, "name", { value: "default", configurable: true });
+/******/ 		};
+/******/ 	})();
+/******/ 	
 /************************************************************************/
-var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be in strict mode.
+let __webpack_exports__ = {};
+// This entry needs to be wrapped in an IIFE because it needs to be in strict mode.
 (() => {
 "use strict";
 
-// EXTERNAL MODULE: ./node_modules/.pnpm/file-saver@2.0.5/node_modules/file-saver/dist/FileSaver.min.js
-var FileSaver_min = __webpack_require__(227);
 // EXTERNAL MODULE: ./src/dealItem.ts
-var dealItem = __webpack_require__(250);
-;// CONCATENATED MODULE: ./node_modules/.pnpm/modern-screenshot@4.4.37/node_modules/modern-screenshot/dist/index.mjs
-var _e = Object.defineProperty, Ue = Object.defineProperties;
-var Pe = Object.getOwnPropertyDescriptors;
-var B = Object.getOwnPropertySymbols;
-var Z = Object.prototype.hasOwnProperty, ee = Object.prototype.propertyIsEnumerable;
-var te = Math.pow, Q = (e, t, r) => t in e ? _e(e, t, { enumerable: !0, configurable: !0, writable: !0, value: r }) : e[t] = r, T = (e, t) => {
-  for (var r in t || (t = {}))
-    Z.call(t, r) && Q(e, r, t[r]);
-  if (B)
-    for (var r of B(t))
-      ee.call(t, r) && Q(e, r, t[r]);
-  return e;
-}, R = (e, t) => Ue(e, Pe(t));
-var re = (e, t) => {
-  var r = {};
-  for (var n in e)
-    Z.call(e, n) && t.indexOf(n) < 0 && (r[n] = e[n]);
-  if (e != null && B)
-    for (var n of B(e))
-      t.indexOf(n) < 0 && ee.call(e, n) && (r[n] = e[n]);
-  return r;
-};
-var S = (e, t, r) => new Promise((n, a) => {
-  var s = (l) => {
-    try {
-      i(r.next(l));
-    } catch (u) {
-      a(u);
-    }
-  }, o = (l) => {
-    try {
-      i(r.throw(l));
-    } catch (u) {
-      a(u);
-    }
-  }, i = (l) => l.done ? n(l.value) : Promise.resolve(l.value).then(s, o);
-  i((r = r.apply(e, t)).next());
-});
-function ue(e, t) {
-  return e[13] = 1, e[14] = t >> 8, e[15] = t & 255, e[16] = t >> 8, e[17] = t & 255, e;
+var dealItem = __webpack_require__(331);
+// EXTERNAL MODULE: ./node_modules/.pnpm/jszip@3.10.1/node_modules/jszip/dist/jszip.min.js
+var jszip_min = __webpack_require__(1);
+;// ./node_modules/.pnpm/modern-screenshot@4.7.0/node_modules/modern-screenshot/dist/index.mjs
+function changeJpegDpi(uint8Array, dpi) {
+  uint8Array[13] = 1;
+  uint8Array[14] = dpi >> 8;
+  uint8Array[15] = dpi & 255;
+  uint8Array[16] = dpi >> 8;
+  uint8Array[17] = dpi & 255;
+  return uint8Array;
 }
-const fe = "p".charCodeAt(0), de = "H".charCodeAt(0), ge = "Y".charCodeAt(0), me = "s".charCodeAt(0);
-let j;
-function $e() {
-  const e = new Int32Array(256);
-  for (let t = 0; t < 256; t++) {
-    let r = t;
-    for (let n = 0; n < 8; n++)
-      r = r & 1 ? 3988292384 ^ r >>> 1 : r >>> 1;
-    e[t] = r;
+
+const _P = "p".charCodeAt(0);
+const _H = "H".charCodeAt(0);
+const _Y = "Y".charCodeAt(0);
+const _S = "s".charCodeAt(0);
+let pngDataTable;
+function createPngDataTable() {
+  const crcTable = new Int32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 3988292384 ^ c >>> 1 : c >>> 1;
+    }
+    crcTable[n] = c;
   }
-  return e;
+  return crcTable;
 }
-function Be(e) {
-  let t = -1;
-  j || (j = $e());
-  for (let r = 0; r < e.length; r++)
-    t = j[(t ^ e[r]) & 255] ^ t >>> 8;
-  return t ^ -1;
+function calcCrc(uint8Array) {
+  let c = -1;
+  if (!pngDataTable)
+    pngDataTable = createPngDataTable();
+  for (let n = 0; n < uint8Array.length; n++) {
+    c = pngDataTable[(c ^ uint8Array[n]) & 255] ^ c >>> 8;
+  }
+  return c ^ -1;
 }
-function Le(e) {
-  const t = e.length - 1;
-  for (let r = t; r >= 4; r--)
-    if (e[r - 4] === 9 && e[r - 3] === fe && e[r - 2] === de && e[r - 1] === ge && e[r] === me)
-      return r - 3;
+function searchStartOfPhys(uint8Array) {
+  const length = uint8Array.length - 1;
+  for (let i = length; i >= 4; i--) {
+    if (uint8Array[i - 4] === 9 && uint8Array[i - 3] === _P && uint8Array[i - 2] === _H && uint8Array[i - 1] === _Y && uint8Array[i] === _S) {
+      return i - 3;
+    }
+  }
   return 0;
 }
-function he(e, t, r = !1) {
-  const n = new Uint8Array(13);
-  t *= 39.3701, n[0] = fe, n[1] = de, n[2] = ge, n[3] = me, n[4] = t >>> 24, n[5] = t >>> 16, n[6] = t >>> 8, n[7] = t & 255, n[8] = n[4], n[9] = n[5], n[10] = n[6], n[11] = n[7], n[12] = 1;
-  const a = Be(n), s = new Uint8Array(4);
-  if (s[0] = a >>> 24, s[1] = a >>> 16, s[2] = a >>> 8, s[3] = a & 255, r) {
-    const o = Le(e);
-    return e.set(n, o), e.set(s, o + 13), e;
+function changePngDpi(uint8Array, dpi, overwritepHYs = false) {
+  const physChunk = new Uint8Array(13);
+  dpi *= 39.3701;
+  physChunk[0] = _P;
+  physChunk[1] = _H;
+  physChunk[2] = _Y;
+  physChunk[3] = _S;
+  physChunk[4] = dpi >>> 24;
+  physChunk[5] = dpi >>> 16;
+  physChunk[6] = dpi >>> 8;
+  physChunk[7] = dpi & 255;
+  physChunk[8] = physChunk[4];
+  physChunk[9] = physChunk[5];
+  physChunk[10] = physChunk[6];
+  physChunk[11] = physChunk[7];
+  physChunk[12] = 1;
+  const crc = calcCrc(physChunk);
+  const crcChunk = new Uint8Array(4);
+  crcChunk[0] = crc >>> 24;
+  crcChunk[1] = crc >>> 16;
+  crcChunk[2] = crc >>> 8;
+  crcChunk[3] = crc & 255;
+  if (overwritepHYs) {
+    const startingIndex = searchStartOfPhys(uint8Array);
+    uint8Array.set(physChunk, startingIndex);
+    uint8Array.set(crcChunk, startingIndex + 13);
+    return uint8Array;
   } else {
-    const o = new Uint8Array(4);
-    o[0] = 0, o[1] = 0, o[2] = 0, o[3] = 9;
-    const i = new Uint8Array(54);
-    return i.set(e, 0), i.set(o, 33), i.set(n, 37), i.set(s, 50), i;
+    const chunkLength = new Uint8Array(4);
+    chunkLength[0] = 0;
+    chunkLength[1] = 0;
+    chunkLength[2] = 0;
+    chunkLength[3] = 9;
+    const finalHeader = new Uint8Array(54);
+    finalHeader.set(uint8Array, 0);
+    finalHeader.set(chunkLength, 33);
+    finalHeader.set(physChunk, 37);
+    finalHeader.set(crcChunk, 50);
+    return finalHeader;
   }
 }
-const Me = "AAlwSFlz", Oe = "AAAJcEhZ", We = "AAAACXBI";
-function qe(e) {
-  let t = e.indexOf(Me);
-  return t === -1 && (t = e.indexOf(Oe)), t === -1 && (t = e.indexOf(We)), t;
+const b64PhysSignature1 = "AAlwSFlz";
+const b64PhysSignature2 = "AAAJcEhZ";
+const b64PhysSignature3 = "AAAACXBI";
+function detectPhysChunkFromDataUrl(dataUrl) {
+  let b64index = dataUrl.indexOf(b64PhysSignature1);
+  if (b64index === -1) {
+    b64index = dataUrl.indexOf(b64PhysSignature2);
+  }
+  if (b64index === -1) {
+    b64index = dataUrl.indexOf(b64PhysSignature3);
+  }
+  return b64index;
 }
-const H = "[modern-screenshot]", x = typeof window != "undefined", je = x && "Worker" in window, we = x && "atob" in window, Ve = x && "btoa" in window;
-var le;
-const z = x ? (le = window.navigator) == null ? void 0 : le.userAgent : "", pe = z.includes("Chrome"), L = z.includes("AppleWebKit") && !pe, X = z.includes("Firefox"), He = (e) => e && "__CONTEXT__" in e, ze = (e) => e.constructor.name === "CSSFontFaceRule", Xe = (e) => e.constructor.name === "CSSImportRule", A = (e) => e.nodeType === 1, U = (e) => typeof e.className == "object", ye = (e) => e.tagName === "image", Ge = (e) => e.tagName === "use", G = (e) => A(e) && typeof e.style != "undefined" && !U(e), Ye = (e) => e.nodeType === 8, Je = (e) => e.nodeType === 3, D = (e) => e.tagName === "IMG", M = (e) => e.tagName === "VIDEO", Ke = (e) => e.tagName === "CANVAS", ne = (e) => e.tagName === "TEXTAREA", Qe = (e) => e.tagName === "INPUT", Ze = (e) => e.tagName === "STYLE", et = (e) => e.tagName === "SCRIPT", tt = (e) => e.tagName === "SELECT", rt = (e) => e.tagName === "SLOT", nt = (e) => e.tagName === "IFRAME", E = (...e) => console.warn(H, ...e), ot = (e) => console.time(`${H} ${e}`), at = (e) => console.timeEnd(`${H} ${e}`), st = (e) => {
-  var r;
-  const t = (r = e == null ? void 0 : e.createElement) == null ? void 0 : r.call(e, "canvas");
-  return t && (t.height = t.width = 1), t && "toDataURL" in t && Boolean(t.toDataURL("image/webp").includes("image/webp"));
-}, V = (e) => e.startsWith("data:");
-function be(e, t) {
-  if (e.match(/^[a-z]+:\/\//i))
-    return e;
-  if (x && e.match(/^\/\//))
-    return window.location.protocol + e;
-  if (e.match(/^[a-z]+:/i) || !x)
-    return e;
-  const r = O().implementation.createHTMLDocument(), n = r.createElement("base"), a = r.createElement("a");
-  return r.head.appendChild(n), r.body.appendChild(a), t && (n.href = t), a.href = e, a.href;
+
+const PREFIX = "[modern-screenshot]";
+const IN_BROWSER = typeof window !== "undefined";
+const SUPPORT_WEB_WORKER = IN_BROWSER && "Worker" in window;
+const SUPPORT_ATOB = IN_BROWSER && "atob" in window;
+const SUPPORT_BTOA = IN_BROWSER && "btoa" in window;
+const USER_AGENT = IN_BROWSER ? window.navigator?.userAgent : "";
+const IN_CHROME = USER_AGENT.includes("Chrome");
+const IN_SAFARI = USER_AGENT.includes("AppleWebKit") && !IN_CHROME;
+const IN_FIREFOX = USER_AGENT.includes("Firefox");
+const isContext = (value) => value && "__CONTEXT__" in value;
+const isCssFontFaceRule = (rule) => rule.constructor.name === "CSSFontFaceRule";
+const isCSSImportRule = (rule) => rule.constructor.name === "CSSImportRule";
+const isLayerBlockRule = (rule) => rule.constructor.name === "CSSLayerBlockRule";
+const isElementNode = (node) => node.nodeType === 1;
+const isSVGElementNode = (node) => typeof node.className === "object";
+const isSVGImageElementNode = (node) => node.tagName === "image";
+const isSVGUseElementNode = (node) => node.tagName === "use";
+const isHTMLElementNode = (node) => isElementNode(node) && typeof node.style !== "undefined" && !isSVGElementNode(node);
+const isCommentNode = (node) => node.nodeType === 8;
+const isTextNode = (node) => node.nodeType === 3;
+const isImageElement = (node) => node.tagName === "IMG";
+const isVideoElement = (node) => node.tagName === "VIDEO";
+const isCanvasElement = (node) => node.tagName === "CANVAS";
+const isTextareaElement = (node) => node.tagName === "TEXTAREA";
+const isInputElement = (node) => node.tagName === "INPUT";
+const isStyleElement = (node) => node.tagName === "STYLE";
+const isScriptElement = (node) => node.tagName === "SCRIPT";
+const isSelectElement = (node) => node.tagName === "SELECT";
+const isSlotElement = (node) => node.tagName === "SLOT";
+const isIFrameElement = (node) => node.tagName === "IFRAME";
+const consoleWarn = (...args) => console.warn(PREFIX, ...args);
+function supportWebp(ownerDocument) {
+  const canvas = ownerDocument?.createElement?.("canvas");
+  if (canvas) {
+    canvas.height = canvas.width = 1;
+  }
+  return Boolean(canvas) && "toDataURL" in canvas && Boolean(canvas.toDataURL("image/webp").includes("image/webp"));
 }
-function O(e) {
-  var t;
-  return (t = e && A(e) ? e == null ? void 0 : e.ownerDocument : e) != null ? t : window.document;
+const isDataUrl = (url) => url.startsWith("data:");
+function resolveUrl(url, baseUrl) {
+  if (url.match(/^[a-z]+:\/\//i))
+    return url;
+  if (IN_BROWSER && url.match(/^\/\//))
+    return window.location.protocol + url;
+  if (url.match(/^[a-z]+:/i))
+    return url;
+  if (!IN_BROWSER)
+    return url;
+  const doc = getDocument().implementation.createHTMLDocument();
+  const base = doc.createElement("base");
+  const a = doc.createElement("a");
+  doc.head.appendChild(base);
+  doc.body.appendChild(a);
+  if (baseUrl)
+    base.href = baseUrl;
+  a.href = url;
+  return a.href;
 }
-const W = "http://www.w3.org/2000/svg";
-function Se(e, t, r) {
-  const n = O(r).createElementNS(W, "svg");
-  return n.setAttributeNS(null, "width", e.toString()), n.setAttributeNS(null, "height", t.toString()), n.setAttributeNS(null, "viewBox", `0 0 ${e} ${t}`), n;
+function getDocument(target) {
+  return (target && isElementNode(target) ? target?.ownerDocument : target) ?? window.document;
 }
-function Ee(e, t) {
-  let r = new XMLSerializer().serializeToString(e);
-  return t && (r = r.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\uD800-\uDFFF\uFFFE\uFFFF]/ug, "")), `data:image/svg+xml;charset=utf-8,${encodeURIComponent(r)}`;
+const XMLNS = "http://www.w3.org/2000/svg";
+function createSvg(width, height, ownerDocument) {
+  const svg = getDocument(ownerDocument).createElementNS(XMLNS, "svg");
+  svg.setAttributeNS(null, "width", width.toString());
+  svg.setAttributeNS(null, "height", height.toString());
+  svg.setAttributeNS(null, "viewBox", `0 0 ${width} ${height}`);
+  return svg;
 }
-function it(e, t = "image/png", r = 1) {
-  return S(this, null, function* () {
-    try {
-      return yield new Promise((n, a) => {
-        e.toBlob((s) => {
-          s ? n(s) : a(new Error("Blob is null"));
-        }, t, r);
-      });
-    } catch (n) {
-      if (we)
-        return E("Failed canvas to blob", { type: t, quality: r }, n), ct(e.toDataURL(t, r));
-      throw n;
+function svgToDataUrl(svg, removeControlCharacter) {
+  let xhtml = new XMLSerializer().serializeToString(svg);
+  if (removeControlCharacter) {
+    xhtml = xhtml.replace(/[\u0000-\u0008\v\f\u000E-\u001F\uD800-\uDFFF\uFFFE\uFFFF]/gu, "");
+  }
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(xhtml)}`;
+}
+async function canvasToBlob(canvas, type = "image/png", quality = 1) {
+  try {
+    return await new Promise((resolve, reject) => {
+      canvas.toBlob((blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error("Blob is null"));
+        }
+      }, type, quality);
+    });
+  } catch (error) {
+    if (SUPPORT_ATOB) {
+      return dataUrlToBlob(canvas.toDataURL(type, quality));
+    }
+    throw error;
+  }
+}
+function dataUrlToBlob(dataUrl) {
+  const [header, base64] = dataUrl.split(",");
+  const type = header.match(/data:(.+);/)?.[1] ?? void 0;
+  const decoded = window.atob(base64);
+  const length = decoded.length;
+  const buffer = new Uint8Array(length);
+  for (let i = 0; i < length; i += 1) {
+    buffer[i] = decoded.charCodeAt(i);
+  }
+  return new Blob([buffer], { type });
+}
+function readBlob(blob, type) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = () => reject(reader.error);
+    reader.onabort = () => reject(new Error(`Failed read blob to ${type}`));
+    if (type === "dataUrl") {
+      reader.readAsDataURL(blob);
+    } else if (type === "arrayBuffer") {
+      reader.readAsArrayBuffer(blob);
     }
   });
 }
-function ct(e) {
-  var i, l;
-  const [t, r] = e.split(","), n = (l = (i = t.match(/data:(.+);/)) == null ? void 0 : i[1]) != null ? l : void 0, a = window.atob(r), s = a.length, o = new Uint8Array(s);
-  for (let u = 0; u < s; u += 1)
-    o[u] = a.charCodeAt(u);
-  return new Blob([o], { type: n });
+const blobToDataUrl = (blob) => readBlob(blob, "dataUrl");
+const blobToArrayBuffer = (blob) => readBlob(blob, "arrayBuffer");
+function createImage(url, ownerDocument) {
+  const img = getDocument(ownerDocument).createElement("img");
+  img.decoding = "sync";
+  img.loading = "eager";
+  img.src = url;
+  return img;
 }
-function Ce(e, t) {
-  return new Promise((r, n) => {
-    const a = new FileReader();
-    a.onload = () => r(a.result), a.onerror = () => n(a.error), a.onabort = () => n(new Error(`Failed read blob to ${t}`)), t === "dataUrl" ? a.readAsDataURL(e) : t === "arrayBuffer" && a.readAsArrayBuffer(e);
-  });
-}
-const lt = (e) => Ce(e, "dataUrl"), ut = (e) => Ce(e, "arrayBuffer");
-function k(e, t) {
-  const r = O(t).createElement("img");
-  return r.decoding = "sync", r.loading = "eager", r.src = e, r;
-}
-function F(e, t) {
-  return new Promise((r) => {
-    const { timeout: n, ownerDocument: a, onError: s } = t != null ? t : {}, o = typeof e == "string" ? k(e, O(a)) : e;
-    let i = null, l = null;
-    function u() {
-      r(o), i && clearTimeout(i), l == null || l();
+function loadMedia(media, options) {
+  return new Promise((resolve) => {
+    const { timeout, ownerDocument, onError: userOnError, onWarn } = options ?? {};
+    const node = typeof media === "string" ? createImage(media, getDocument(ownerDocument)) : media;
+    let timer = null;
+    let removeEventListeners = null;
+    function onResolve() {
+      resolve(node);
+      timer && clearTimeout(timer);
+      removeEventListeners?.();
     }
-    if (n && (i = setTimeout(u, n)), M(o)) {
-      const c = o.currentSrc || o.src;
-      if (!c)
-        return o.poster ? F(o.poster, t).then(r) : u();
-      if (o.readyState >= 2)
-        return u();
-      const f = u, d = (g) => {
-        E(
+    if (timeout) {
+      timer = setTimeout(onResolve, timeout);
+    }
+    if (isVideoElement(node)) {
+      const currentSrc = node.currentSrc || node.src;
+      if (!currentSrc) {
+        if (node.poster) {
+          return loadMedia(node.poster, options).then(resolve);
+        }
+        return onResolve();
+      }
+      if (node.readyState >= 2) {
+        return onResolve();
+      }
+      const onLoadeddata = onResolve;
+      const onError = (error) => {
+        onWarn?.(
           "Failed video load",
-          c,
-          g
-        ), s == null || s(g), u();
+          currentSrc,
+          error
+        );
+        userOnError?.(error);
+        onResolve();
       };
-      l = () => {
-        o.removeEventListener("loadeddata", f), o.removeEventListener("error", d);
-      }, o.addEventListener("loadeddata", f, { once: !0 }), o.addEventListener("error", d, { once: !0 });
+      removeEventListeners = () => {
+        node.removeEventListener("loadeddata", onLoadeddata);
+        node.removeEventListener("error", onError);
+      };
+      node.addEventListener("loadeddata", onLoadeddata, { once: true });
+      node.addEventListener("error", onError, { once: true });
     } else {
-      const c = ye(o) ? o.href.baseVal : o.currentSrc || o.src;
-      if (!c)
-        return u();
-      const f = () => S(this, null, function* () {
-        if (D(o) && "decode" in o)
+      const currentSrc = isSVGImageElementNode(node) ? node.href.baseVal : node.currentSrc || node.src;
+      if (!currentSrc) {
+        return onResolve();
+      }
+      const onLoad = async () => {
+        if (isImageElement(node) && "decode" in node) {
           try {
-            yield o.decode();
-          } catch (g) {
-            E(
+            await node.decode();
+          } catch (error) {
+            onWarn?.(
               "Failed to decode image, trying to render anyway",
-              o.dataset.originalSrc || c,
-              g
+              node.dataset.originalSrc || currentSrc,
+              error
             );
           }
-        u();
-      }), d = (g) => {
-        E(
-          "Failed image load",
-          o.dataset.originalSrc || c,
-          g
-        ), u();
+        }
+        onResolve();
       };
-      if (D(o) && o.complete)
-        return f();
-      l = () => {
-        o.removeEventListener("load", f), o.removeEventListener("error", d);
-      }, o.addEventListener("load", f, { once: !0 }), o.addEventListener("error", d, { once: !0 });
+      const onError = (error) => {
+        onWarn?.(
+          "Failed image load",
+          node.dataset.originalSrc || currentSrc,
+          error
+        );
+        onResolve();
+      };
+      if (isImageElement(node) && node.complete) {
+        return onLoad();
+      }
+      removeEventListeners = () => {
+        node.removeEventListener("load", onLoad);
+        node.removeEventListener("error", onError);
+      };
+      node.addEventListener("load", onLoad, { once: true });
+      node.addEventListener("error", onError, { once: true });
     }
   });
 }
-function ft(e, t) {
-  return S(this, null, function* () {
-    G(e) && (D(e) || M(e) ? yield F(e, { timeout: t }) : yield Promise.all(
-      ["img", "video"].flatMap((r) => Array.from(e.querySelectorAll(r)).map((n) => F(n, { timeout: t })))
-    ));
-  });
+async function waitUntilLoad(node, options) {
+  if (isHTMLElementNode(node)) {
+    if (isImageElement(node) || isVideoElement(node)) {
+      await loadMedia(node, options);
+    } else {
+      await Promise.all(
+        ["img", "video"].flatMap((selectors) => {
+          return Array.from(node.querySelectorAll(selectors)).map((el) => loadMedia(el, options));
+        })
+      );
+    }
+  }
 }
-const ve = function() {
-  let t = 0;
-  const r = () => (
-    // eslint-disable-next-line no-bitwise
-    `0000${(Math.random() * te(36, 4) << 0).toString(36)}`.slice(-4)
-  );
-  return () => (t += 1, `u${r()}${t}`);
+const uuid = /* @__PURE__ */ function uuid2() {
+  let counter = 0;
+  const random = () => `0000${(Math.random() * 36 ** 4 << 0).toString(36)}`.slice(-4);
+  return () => {
+    counter += 1;
+    return `u${random()}${counter}`;
+  };
 }();
-function Te(e) {
-  return e == null ? void 0 : e.split(",").map((t) => t.trim().replace(/"|'/g, "").toLowerCase()).filter(Boolean);
+function splitFontFamily(fontFamily) {
+  return fontFamily?.split(",").map((val) => val.trim().replace(/"|'/g, "").toLowerCase()).filter(Boolean);
 }
-function dt(e) {
+
+let uid = 0;
+function createLogger(debug) {
+  const prefix = `${PREFIX}[#${uid}]`;
+  uid++;
   return {
-    time: (t) => e && ot(t),
-    timeEnd: (t) => e && at(t),
-    warn: (...t) => e && E(...t)
+    // eslint-disable-next-line no-console
+    time: (label) => debug && console.time(`${prefix} ${label}`),
+    // eslint-disable-next-line no-console
+    timeEnd: (label) => debug && console.timeEnd(`${prefix} ${label}`),
+    warn: (...args) => debug && consoleWarn(...args)
   };
 }
-function gt(e) {
+
+function getDefaultRequestInit(bypassingCache) {
   return {
-    cache: e ? "no-cache" : "force-cache"
+    cache: bypassingCache ? "no-cache" : "force-cache"
   };
 }
-function N(e, t) {
-  return S(this, null, function* () {
-    return He(e) ? e : mt(e, R(T({}, t), { autoDestruct: !0 }));
-  });
+
+async function orCreateContext(node, options) {
+  return isContext(node) ? node : createContext(node, { ...options, autoDestruct: true });
 }
-function mt(e, t) {
-  return S(this, null, function* () {
-    var g, h, w, y, m;
-    const { scale: r = 1, workerUrl: n, workerNumber: a = 1 } = t || {}, s = Boolean(t == null ? void 0 : t.debug), o = (g = t == null ? void 0 : t.features) != null ? g : !0, i = (h = e.ownerDocument) != null ? h : x ? window.document : void 0, l = (y = (w = e.ownerDocument) == null ? void 0 : w.defaultView) != null ? y : x ? window : void 0, u = /* @__PURE__ */ new Map(), c = R(T({
-      // Options
-      width: 0,
-      height: 0,
-      quality: 1,
-      type: "image/png",
-      scale: r,
-      backgroundColor: null,
-      style: null,
-      filter: null,
-      maximumCanvasSize: 0,
-      timeout: 3e4,
-      progress: null,
-      debug: s,
-      fetch: T({
-        requestInit: gt((m = t == null ? void 0 : t.fetch) == null ? void 0 : m.bypassingCache),
-        placeholderImage: "data:image/png;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
-        bypassingCache: !1
-      }, t == null ? void 0 : t.fetch),
-      fetchFn: null,
-      font: {},
-      drawImageInterval: 100,
-      workerUrl: null,
-      workerNumber: a,
-      onCloneNode: null,
-      onEmbedNode: null,
-      onCreateForeignObjectSvg: null,
-      includeStyleProperties: null,
-      autoDestruct: !1
-    }, t), {
-      // InternalContext
-      __CONTEXT__: !0,
-      log: dt(s),
-      node: e,
-      ownerDocument: i,
-      ownerWindow: l,
-      dpi: r === 1 ? null : 96 * r,
-      svgStyleElement: Ae(i),
-      svgDefsElement: i == null ? void 0 : i.createElementNS(W, "defs"),
-      svgStyles: /* @__PURE__ */ new Map(),
-      defaultComputedStyles: /* @__PURE__ */ new Map(),
-      workers: [
-        ...new Array(
-          je && n && a ? a : 0
-        )
-      ].map(() => {
-        try {
-          const b = new Worker(n);
-          return b.onmessage = (p) => S(this, null, function* () {
-            var I, J, $, K;
-            const { url: C, result: v } = p.data;
-            v ? (J = (I = u.get(C)) == null ? void 0 : I.resolve) == null || J.call(I, v) : (K = ($ = u.get(C)) == null ? void 0 : $.reject) == null || K.call($, new Error(`Error receiving message from worker: ${C}`));
-          }), b.onmessageerror = (p) => {
-            var v, I;
-            const { url: C } = p.data;
-            (I = (v = u.get(C)) == null ? void 0 : v.reject) == null || I.call(v, new Error(`Error receiving message from worker: ${C}`));
-          }, b;
-        } catch (b) {
-          return E("Failed to new Worker", b), null;
-        }
-      }).filter(Boolean),
-      fontFamilies: /* @__PURE__ */ new Set(),
-      fontCssTexts: /* @__PURE__ */ new Map(),
-      acceptOfImage: `${[
-        st(i) && "image/webp",
-        "image/svg+xml",
-        "image/*",
-        "*/*"
-      ].filter(Boolean).join(",")};q=0.8`,
-      requests: u,
-      drawImageCount: 0,
-      tasks: [],
-      features: o,
-      isEnable: (b) => {
-        var p;
-        return typeof o == "boolean" ? o : (p = o[b]) != null ? p : !0;
+async function createContext(node, options) {
+  const { scale = 1, workerUrl, workerNumber = 1 } = options || {};
+  const debug = Boolean(options?.debug);
+  const features = options?.features ?? true;
+  const ownerDocument = node.ownerDocument ?? (IN_BROWSER ? window.document : void 0);
+  const ownerWindow = node.ownerDocument?.defaultView ?? (IN_BROWSER ? window : void 0);
+  const requests = /* @__PURE__ */ new Map();
+  const context = {
+    // Options
+    width: 0,
+    height: 0,
+    quality: 1,
+    type: "image/png",
+    scale,
+    backgroundColor: null,
+    style: null,
+    filter: null,
+    maximumCanvasSize: 0,
+    timeout: 3e4,
+    progress: null,
+    debug,
+    fetch: {
+      requestInit: getDefaultRequestInit(options?.fetch?.bypassingCache),
+      placeholderImage: "data:image/png;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+      bypassingCache: false,
+      ...options?.fetch
+    },
+    fetchFn: null,
+    font: {},
+    drawImageInterval: 100,
+    workerUrl: null,
+    workerNumber,
+    onCloneEachNode: null,
+    onCloneNode: null,
+    onEmbedNode: null,
+    onCreateForeignObjectSvg: null,
+    includeStyleProperties: null,
+    autoDestruct: false,
+    ...options,
+    // InternalContext
+    __CONTEXT__: true,
+    log: createLogger(debug),
+    node,
+    ownerDocument,
+    ownerWindow,
+    dpi: scale === 1 ? null : 96 * scale,
+    svgStyleElement: createStyleElement(ownerDocument),
+    svgDefsElement: ownerDocument?.createElementNS(XMLNS, "defs"),
+    svgStyles: /* @__PURE__ */ new Map(),
+    defaultComputedStyles: /* @__PURE__ */ new Map(),
+    workers: [
+      ...Array.from({
+        length: SUPPORT_WEB_WORKER && workerUrl && workerNumber ? workerNumber : 0
+      })
+    ].map(() => {
+      try {
+        const worker = new Worker(workerUrl);
+        worker.onmessage = async (event) => {
+          const { url, result } = event.data;
+          if (result) {
+            requests.get(url)?.resolve?.(result);
+          } else {
+            requests.get(url)?.reject?.(new Error(`Error receiving message from worker: ${url}`));
+          }
+        };
+        worker.onmessageerror = (event) => {
+          const { url } = event.data;
+          requests.get(url)?.reject?.(new Error(`Error receiving message from worker: ${url}`));
+        };
+        return worker;
+      } catch (error) {
+        context.log.warn("Failed to new Worker", error);
+        return null;
       }
-    });
-    c.log.time("wait until load"), yield ft(e, c.timeout), c.log.timeEnd("wait until load");
-    const { width: f, height: d } = ht(e, c);
-    return c.width = f, c.height = d, c;
-  });
+    }).filter(Boolean),
+    fontFamilies: /* @__PURE__ */ new Map(),
+    fontCssTexts: /* @__PURE__ */ new Map(),
+    acceptOfImage: `${[
+      supportWebp(ownerDocument) && "image/webp",
+      "image/svg+xml",
+      "image/*",
+      "*/*"
+    ].filter(Boolean).join(",")};q=0.8`,
+    requests,
+    drawImageCount: 0,
+    tasks: [],
+    features,
+    isEnable: (key) => {
+      if (key === "restoreScrollPosition") {
+        return typeof features === "boolean" ? false : features[key] ?? false;
+      }
+      if (typeof features === "boolean") {
+        return features;
+      }
+      return features[key] ?? true;
+    },
+    shadowRoots: []
+  };
+  context.log.time("wait until load");
+  await waitUntilLoad(node, { timeout: context.timeout, onWarn: context.log.warn });
+  context.log.timeEnd("wait until load");
+  const { width, height } = resolveBoundingBox(node, context);
+  context.width = width;
+  context.height = height;
+  return context;
 }
-function Ae(e) {
-  if (!e)
-    return;
-  const t = e.createElement("style"), r = t.ownerDocument.createTextNode(`
+function createStyleElement(ownerDocument) {
+  if (!ownerDocument)
+    return void 0;
+  const style = ownerDocument.createElement("style");
+  const cssText = style.ownerDocument.createTextNode(`
 .______background-clip--text {
   background-clip: text;
   -webkit-background-clip: text;
 }
 `);
-  return t.appendChild(r), t;
+  style.appendChild(cssText);
+  return style;
 }
-function ht(e, t) {
-  let { width: r, height: n } = t;
-  if (A(e) && (!r || !n)) {
-    const a = e.getBoundingClientRect();
-    r = r || a.width || Number(e.getAttribute("width")) || 0, n = n || a.height || Number(e.getAttribute("height")) || 0;
+function resolveBoundingBox(node, context) {
+  let { width, height } = context;
+  if (isElementNode(node) && (!width || !height)) {
+    const box = node.getBoundingClientRect();
+    width = width || box.width || Number(node.getAttribute("width")) || 0;
+    height = height || box.height || Number(node.getAttribute("height")) || 0;
   }
-  return { width: r, height: n };
+  return { width, height };
 }
-function wt(e, t) {
-  return S(this, null, function* () {
-    const {
-      log: r,
-      timeout: n,
-      drawImageCount: a,
-      drawImageInterval: s
-    } = t;
-    r.time("image to canvas");
-    const o = yield F(e, { timeout: n }), { canvas: i, context2d: l } = pt(e.ownerDocument, t), u = () => {
-      try {
-        l == null || l.drawImage(o, 0, 0, i.width, i.height);
-      } catch (c) {
-        E("Failed to drawImage", c);
+
+async function imageToCanvas(image, context) {
+  const {
+    log,
+    timeout,
+    drawImageCount,
+    drawImageInterval
+  } = context;
+  log.time("image to canvas");
+  const loaded = await loadMedia(image, { timeout, onWarn: context.log.warn });
+  const { canvas, context2d } = createCanvas(image.ownerDocument, context);
+  const drawImage = () => {
+    try {
+      context2d?.drawImage(loaded, 0, 0, canvas.width, canvas.height);
+    } catch (error) {
+      context.log.warn("Failed to drawImage", error);
+    }
+  };
+  drawImage();
+  if (context.isEnable("fixSvgXmlDecode")) {
+    for (let i = 0; i < drawImageCount; i++) {
+      await new Promise((resolve) => {
+        setTimeout(() => {
+          context2d?.clearRect(0, 0, canvas.width, canvas.height);
+          drawImage();
+          resolve();
+        }, i + drawImageInterval);
+      });
+    }
+  }
+  context.drawImageCount = 0;
+  log.timeEnd("image to canvas");
+  return canvas;
+}
+function createCanvas(ownerDocument, context) {
+  const { width, height, scale, backgroundColor, maximumCanvasSize: max } = context;
+  const canvas = ownerDocument.createElement("canvas");
+  canvas.width = Math.floor(width * scale);
+  canvas.height = Math.floor(height * scale);
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  if (max) {
+    if (canvas.width > max || canvas.height > max) {
+      if (canvas.width > max && canvas.height > max) {
+        if (canvas.width > canvas.height) {
+          canvas.height *= max / canvas.width;
+          canvas.width = max;
+        } else {
+          canvas.width *= max / canvas.height;
+          canvas.height = max;
+        }
+      } else if (canvas.width > max) {
+        canvas.height *= max / canvas.width;
+        canvas.width = max;
+      } else {
+        canvas.width *= max / canvas.height;
+        canvas.height = max;
       }
-    };
-    if (u(), t.isEnable("fixSvgXmlDecode"))
-      for (let c = 0; c < a; c++)
-        yield new Promise((f) => {
-          setTimeout(() => {
-            u(), f();
-          }, c + s);
-        });
-    return t.drawImageCount = 0, r.timeEnd("image to canvas"), i;
-  });
+    }
+  }
+  const context2d = canvas.getContext("2d");
+  if (context2d && backgroundColor) {
+    context2d.fillStyle = backgroundColor;
+    context2d.fillRect(0, 0, canvas.width, canvas.height);
+  }
+  return { canvas, context2d };
 }
-function pt(e, t) {
-  const { width: r, height: n, scale: a, backgroundColor: s, maximumCanvasSize: o } = t, i = e.createElement("canvas");
-  i.width = Math.floor(r * a), i.height = Math.floor(n * a), i.style.width = `${r}px`, i.style.height = `${n}px`, o && (i.width > o || i.height > o) && (i.width > o && i.height > o ? i.width > i.height ? (i.height *= o / i.width, i.width = o) : (i.width *= o / i.height, i.height = o) : i.width > o ? (i.height *= o / i.width, i.width = o) : (i.width *= o / i.height, i.height = o));
-  const l = i.getContext("2d");
-  return l && s && (l.fillStyle = s, l.fillRect(0, 0, i.width, i.height)), { canvas: i, context2d: l };
+
+function cloneCanvas(canvas, context) {
+  if (canvas.ownerDocument) {
+    try {
+      const dataURL = canvas.toDataURL();
+      if (dataURL !== "data:,") {
+        return createImage(dataURL, canvas.ownerDocument);
+      }
+    } catch (error) {
+      context.log.warn("Failed to clone canvas", error);
+    }
+  }
+  const cloned = canvas.cloneNode(false);
+  const ctx = canvas.getContext("2d");
+  const clonedCtx = cloned.getContext("2d");
+  try {
+    if (ctx && clonedCtx) {
+      clonedCtx.putImageData(
+        ctx.getImageData(0, 0, canvas.width, canvas.height),
+        0,
+        0
+      );
+    }
+    return cloned;
+  } catch (error) {
+    context.log.warn("Failed to clone canvas", error);
+  }
+  return cloned;
 }
-const yt = [
+
+function cloneIframe(iframe, context) {
+  try {
+    if (iframe?.contentDocument?.documentElement) {
+      return cloneNode(iframe.contentDocument.documentElement, context);
+    }
+  } catch (error) {
+    context.log.warn("Failed to clone iframe", error);
+  }
+  return iframe.cloneNode(false);
+}
+
+function cloneImage(image) {
+  const cloned = image.cloneNode(false);
+  if (image.currentSrc && image.currentSrc !== image.src) {
+    cloned.src = image.currentSrc;
+    cloned.srcset = "";
+  }
+  if (cloned.loading === "lazy") {
+    cloned.loading = "eager";
+  }
+  return cloned;
+}
+
+async function cloneVideo(video, context) {
+  if (video.ownerDocument && !video.currentSrc && video.poster) {
+    return createImage(video.poster, video.ownerDocument);
+  }
+  const cloned = video.cloneNode(false);
+  cloned.crossOrigin = "anonymous";
+  if (video.currentSrc && video.currentSrc !== video.src) {
+    cloned.src = video.currentSrc;
+  }
+  const ownerDocument = cloned.ownerDocument;
+  if (ownerDocument) {
+    let canPlay = true;
+    await loadMedia(cloned, { onError: () => canPlay = false, onWarn: context.log.warn });
+    if (!canPlay) {
+      if (video.poster) {
+        return createImage(video.poster, video.ownerDocument);
+      }
+      return cloned;
+    }
+    cloned.currentTime = video.currentTime;
+    await new Promise((resolve) => {
+      cloned.addEventListener("seeked", resolve, { once: true });
+    });
+    const canvas = ownerDocument.createElement("canvas");
+    canvas.width = video.offsetWidth;
+    canvas.height = video.offsetHeight;
+    try {
+      const ctx = canvas.getContext("2d");
+      if (ctx)
+        ctx.drawImage(cloned, 0, 0, canvas.width, canvas.height);
+    } catch (error) {
+      context.log.warn("Failed to clone video", error);
+      if (video.poster) {
+        return createImage(video.poster, video.ownerDocument);
+      }
+      return cloned;
+    }
+    return cloneCanvas(canvas, context);
+  }
+  return cloned;
+}
+
+function cloneElement(node, context) {
+  if (isCanvasElement(node)) {
+    return cloneCanvas(node, context);
+  }
+  if (isIFrameElement(node)) {
+    return cloneIframe(node, context);
+  }
+  if (isImageElement(node)) {
+    return cloneImage(node);
+  }
+  if (isVideoElement(node)) {
+    return cloneVideo(node, context);
+  }
+  return node.cloneNode(false);
+}
+
+function getSandBox(context) {
+  let sandbox = context.sandbox;
+  if (!sandbox) {
+    const { ownerDocument } = context;
+    try {
+      if (ownerDocument) {
+        sandbox = ownerDocument.createElement("iframe");
+        sandbox.id = `__SANDBOX__${uuid()}`;
+        sandbox.width = "0";
+        sandbox.height = "0";
+        sandbox.style.visibility = "hidden";
+        sandbox.style.position = "fixed";
+        ownerDocument.body.appendChild(sandbox);
+        sandbox.srcdoc = '<!DOCTYPE html><meta charset="UTF-8"><title></title><body>';
+        context.sandbox = sandbox;
+      }
+    } catch (error) {
+      context.log.warn("Failed to getSandBox", error);
+    }
+  }
+  return sandbox;
+}
+
+const ignoredStyles = [
   "width",
   "height",
   "-webkit-text-fill-color"
-], bt = [
+];
+const includedAttributes = [
   "stroke",
   "fill"
 ];
-function Ne(e, t, r) {
-  var y;
-  const { defaultComputedStyles: n, ownerDocument: a } = r, s = e.nodeName.toLowerCase(), o = U(e) && s !== "svg", i = o ? bt.map((m) => [m, e.getAttribute(m)]).filter(([, m]) => m !== null) : [], l = [
-    o && "svg",
-    s,
-    i.map((m, b) => `${m}=${b}`).join(","),
-    t
+function getDefaultStyle(node, pseudoElement, context) {
+  const { defaultComputedStyles } = context;
+  const nodeName = node.nodeName.toLowerCase();
+  const isSvgNode = isSVGElementNode(node) && nodeName !== "svg";
+  const attributes = isSvgNode ? includedAttributes.map((name) => [name, node.getAttribute(name)]).filter(([, value]) => value !== null) : [];
+  const key = [
+    isSvgNode && "svg",
+    nodeName,
+    attributes.map((name, value) => `${name}=${value}`).join(","),
+    pseudoElement
   ].filter(Boolean).join(":");
-  if (n.has(l))
-    return n.get(l);
-  let u = r.sandbox;
-  if (!u)
-    try {
-      a && (u = a.createElement("iframe"), u.id = `__SANDBOX__-${ve()}`, u.width = "0", u.height = "0", u.style.visibility = "hidden", u.style.position = "fixed", a.body.appendChild(u), (y = u.contentWindow) == null || y.document.write('<!DOCTYPE html><meta charset="UTF-8"><title></title><body>'), r.sandbox = u);
-    } catch (m) {
-      E("Failed to create iframe sandbox", m);
-    }
-  if (!u)
+  if (defaultComputedStyles.has(key))
+    return defaultComputedStyles.get(key);
+  const sandbox = getSandBox(context);
+  const sandboxWindow = sandbox?.contentWindow;
+  if (!sandboxWindow)
     return /* @__PURE__ */ new Map();
-  const c = u.contentWindow;
-  if (!c)
-    return /* @__PURE__ */ new Map();
-  const f = c.document;
-  let d, g;
-  o ? (d = f.createElementNS(W, "svg"), g = d.ownerDocument.createElementNS(d.namespaceURI, s), i.forEach(([m, b]) => {
-    g.setAttributeNS(null, m, b);
-  }), d.appendChild(g)) : d = g = f.createElement(s), g.textContent = " ", f.body.appendChild(d);
-  const h = c.getComputedStyle(g, t), w = /* @__PURE__ */ new Map();
-  for (let m = h.length, b = 0; b < m; b++) {
-    const p = h.item(b);
-    yt.includes(p) || w.set(p, h.getPropertyValue(p));
-  }
-  return f.body.removeChild(d), n.set(l, w), w;
-}
-function Ie(e, t, r) {
-  var i;
-  const n = /* @__PURE__ */ new Map(), a = [], s = /* @__PURE__ */ new Map();
-  if (r)
-    for (const l of r)
-      o(l);
-  else
-    for (let l = e.length, u = 0; u < l; u++) {
-      const c = e.item(u);
-      o(c);
-    }
-  for (let l = a.length, u = 0; u < l; u++)
-    (i = s.get(a[u])) == null || i.forEach((c, f) => n.set(f, c));
-  function o(l) {
-    const u = e.getPropertyValue(l), c = e.getPropertyPriority(l), f = l.lastIndexOf("-"), d = f > -1 ? l.substring(0, f) : void 0;
-    if (d) {
-      let g = s.get(d);
-      g || (g = /* @__PURE__ */ new Map(), s.set(d, g)), g.set(l, [u, c]);
-    }
-    t.get(l) === u && !c || (d ? a.push(d) : n.set(l, [u, c]));
-  }
-  return n;
-}
-const St = [
-  ":before",
-  ":after"
-  // ':placeholder', TODO
-], Et = [
-  ":-webkit-scrollbar",
-  ":-webkit-scrollbar-button",
-  // ':-webkit-scrollbar:horizontal', TODO
-  ":-webkit-scrollbar-thumb",
-  ":-webkit-scrollbar-track",
-  ":-webkit-scrollbar-track-piece",
-  // ':-webkit-scrollbar:vertical', TODO
-  ":-webkit-scrollbar-corner",
-  ":-webkit-resizer"
-];
-function Ct(e, t, r, n) {
-  const { ownerWindow: a, svgStyleElement: s, svgStyles: o, currentNodeStyle: i } = n;
-  if (!s || !a)
-    return;
-  function l(u) {
-    var b;
-    const c = a.getComputedStyle(e, u);
-    let f = c.getPropertyValue("content");
-    if (!f || f === "none")
-      return;
-    f = f.replace(/(')|(")|(counter\(.+\))/g, "");
-    const d = [ve()], g = Ne(e, u, n);
-    i == null || i.forEach((p, C) => {
-      g.delete(C);
+  const sandboxDocument = sandboxWindow?.document;
+  let root;
+  let el;
+  if (isSvgNode) {
+    root = sandboxDocument.createElementNS(XMLNS, "svg");
+    el = root.ownerDocument.createElementNS(root.namespaceURI, nodeName);
+    attributes.forEach(([name, value]) => {
+      el.setAttributeNS(null, name, value);
     });
-    const h = Ie(c, g, n.includeStyleProperties);
-    h.delete("content"), h.delete("-webkit-locale"), ((b = h.get("background-clip")) == null ? void 0 : b[0]) === "text" && t.classList.add("______background-clip--text");
-    const w = [
-      `content: '${f}';`
-    ];
-    if (h.forEach(([p, C], v) => {
-      w.push(`${v}: ${p}${C ? " !important" : ""};`);
-    }), w.length === 1)
-      return;
-    try {
-      t.className = [t.className, ...d].join(" ");
-    } catch (p) {
-      return;
+    root.appendChild(el);
+  } else {
+    root = el = sandboxDocument.createElement(nodeName);
+  }
+  el.textContent = " ";
+  sandboxDocument.body.appendChild(root);
+  const computedStyle = sandboxWindow.getComputedStyle(el, pseudoElement);
+  const styles = /* @__PURE__ */ new Map();
+  for (let len = computedStyle.length, i = 0; i < len; i++) {
+    const name = computedStyle.item(i);
+    if (ignoredStyles.includes(name))
+      continue;
+    styles.set(name, computedStyle.getPropertyValue(name));
+  }
+  sandboxDocument.body.removeChild(root);
+  defaultComputedStyles.set(key, styles);
+  return styles;
+}
+
+function getDiffStyle(style, defaultStyle, includeStyleProperties) {
+  const diffStyle = /* @__PURE__ */ new Map();
+  const prefixs = [];
+  const prefixTree = /* @__PURE__ */ new Map();
+  if (includeStyleProperties) {
+    for (const name of includeStyleProperties) {
+      applyTo(name);
     }
-    const y = w.join(`
-  `);
-    let m = o.get(y);
-    m || (m = [], o.set(y, m)), m.push(`.${d[0]}:${u}`);
-  }
-  St.forEach(l), r && Et.forEach(l);
-}
-function vt(e, t) {
-  ne(e) && (t.innerHTML = e.value), (ne(e) || Qe(e) || tt(e)) && t.setAttribute("value", e.value);
-}
-function Tt(e, t, r, n) {
-  var f, d, g, h;
-  const { ownerWindow: a, includeStyleProperties: s, currentParentNodeStyle: o } = n, i = t.style, l = a.getComputedStyle(e), u = Ne(e, null, n);
-  o == null || o.forEach((w, y) => {
-    u.delete(y);
-  });
-  const c = Ie(l, u, s);
-  return c.delete("transition-property"), c.delete("all"), c.delete("d"), c.delete("content"), r && (c.delete("margin-top"), c.delete("margin-right"), c.delete("margin-bottom"), c.delete("margin-left"), c.delete("margin-block-start"), c.delete("margin-block-end"), c.delete("margin-inline-start"), c.delete("margin-inline-end"), c.set("box-sizing", ["border-box", ""])), ((f = c.get("background-clip")) == null ? void 0 : f[0]) === "text" && t.classList.add("______background-clip--text"), pe && (c.has("font-kerning") || c.set("font-kerning", ["normal", ""]), (((d = c.get("overflow-x")) == null ? void 0 : d[0]) === "hidden" || ((g = c.get("overflow-y")) == null ? void 0 : g[0]) === "hidden") && ((h = c.get("text-overflow")) == null ? void 0 : h[0]) === "ellipsis" && e.scrollWidth === e.clientWidth && c.set("text-overflow", ["clip", ""])), c.forEach(([w, y], m) => {
-    i.setProperty(m, w, y);
-  }), c;
-}
-function At(e, t) {
-  var r;
-  try {
-    if ((r = e == null ? void 0 : e.contentDocument) != null && r.body)
-      return q(e.contentDocument.body, t);
-  } catch (n) {
-    E("Failed to clone iframe", n);
-  }
-  return e.cloneNode(!1);
-}
-function xe(e) {
-  if (e.ownerDocument)
-    try {
-      const a = e.toDataURL();
-      if (a !== "data:,")
-        return k(a, e.ownerDocument);
-    } catch (a) {
+  } else {
+    for (let len = style.length, i = 0; i < len; i++) {
+      const name = style.item(i);
+      applyTo(name);
     }
-  const t = e.cloneNode(!1), r = e.getContext("2d"), n = t.getContext("2d");
-  try {
-    return r && n && n.putImageData(
-      r.getImageData(0, 0, e.width, e.height),
-      0,
-      0
-    ), t;
-  } catch (a) {
-    E("Failed to clone canvas", a);
   }
-  return t;
-}
-function Nt(e) {
-  return S(this, null, function* () {
-    if (e.ownerDocument && !e.currentSrc && e.poster)
-      return k(e.poster, e.ownerDocument);
-    const t = e.cloneNode(!1);
-    t.crossOrigin = "anonymous", e.currentSrc && e.currentSrc !== e.src && (t.src = e.currentSrc);
-    const r = t.ownerDocument;
-    if (r) {
-      let n = !0;
-      if (yield F(t, {
-        onError: () => n = !1
-      }), !n)
-        return e.poster ? k(e.poster, e.ownerDocument) : t;
-      t.currentTime = e.currentTime, yield new Promise((s) => {
-        t.addEventListener("seeked", s, { once: !0 });
-      });
-      const a = r.createElement("canvas");
-      a.width = e.offsetWidth, a.height = e.offsetHeight;
-      try {
-        const s = a.getContext("2d");
-        s && s.drawImage(t, 0, 0, a.width, a.height);
-      } catch (s) {
-        return E("Failed to clone video", s), e.poster ? k(e.poster, e.ownerDocument) : t;
+  for (let len = prefixs.length, i = 0; i < len; i++) {
+    prefixTree.get(prefixs[i])?.forEach((value, name) => diffStyle.set(name, value));
+  }
+  function applyTo(name) {
+    const value = style.getPropertyValue(name);
+    const priority = style.getPropertyPriority(name);
+    const subIndex = name.lastIndexOf("-");
+    const prefix = subIndex > -1 ? name.substring(0, subIndex) : void 0;
+    if (prefix) {
+      let map = prefixTree.get(prefix);
+      if (!map) {
+        map = /* @__PURE__ */ new Map();
+        prefixTree.set(prefix, map);
       }
-      return xe(a);
+      map.set(name, [value, priority]);
     }
-    return t;
+    if (defaultStyle.get(name) === value && !priority)
+      return;
+    if (prefix) {
+      prefixs.push(prefix);
+    } else {
+      diffStyle.set(name, [value, priority]);
+    }
+  }
+  return diffStyle;
+}
+
+function copyCssStyles(node, cloned, isRoot, context) {
+  const { ownerWindow, includeStyleProperties, currentParentNodeStyle } = context;
+  const clonedStyle = cloned.style;
+  const computedStyle = ownerWindow.getComputedStyle(node);
+  const defaultStyle = getDefaultStyle(node, null, context);
+  currentParentNodeStyle?.forEach((_, key) => {
+    defaultStyle.delete(key);
   });
+  const style = getDiffStyle(computedStyle, defaultStyle, includeStyleProperties);
+  style.delete("transition-property");
+  style.delete("all");
+  style.delete("d");
+  style.delete("content");
+  if (isRoot) {
+    style.delete("position");
+    style.delete("margin-top");
+    style.delete("margin-right");
+    style.delete("margin-bottom");
+    style.delete("margin-left");
+    style.delete("margin-block-start");
+    style.delete("margin-block-end");
+    style.delete("margin-inline-start");
+    style.delete("margin-inline-end");
+    style.set("box-sizing", ["border-box", ""]);
+  }
+  if (style.get("background-clip")?.[0] === "text") {
+    cloned.classList.add("______background-clip--text");
+  }
+  if (IN_CHROME) {
+    if (!style.has("font-kerning"))
+      style.set("font-kerning", ["normal", ""]);
+    if ((style.get("overflow-x")?.[0] === "hidden" || style.get("overflow-y")?.[0] === "hidden") && style.get("text-overflow")?.[0] === "ellipsis" && node.scrollWidth === node.clientWidth) {
+      style.set("text-overflow", ["clip", ""]);
+    }
+  }
+  for (let len = clonedStyle.length, i = 0; i < len; i++) {
+    clonedStyle.removeProperty(clonedStyle.item(i));
+  }
+  style.forEach(([value, priority], name) => {
+    clonedStyle.setProperty(name, value, priority);
+  });
+  return style;
 }
-function It(e) {
-  const t = e.cloneNode(!1);
-  return e.currentSrc && e.currentSrc !== e.src && (t.src = e.currentSrc, t.srcset = ""), t.loading === "lazy" && (t.loading = "eager"), t;
+
+function copyInputValue(node, cloned) {
+  if (isTextareaElement(node) || isInputElement(node) || isSelectElement(node)) {
+    cloned.setAttribute("value", node.value);
+  }
 }
-function xt(e, t) {
-  return Ke(e) ? xe(e) : nt(e) ? At(e, t) : D(e) ? It(e) : M(e) ? Nt(e) : e.cloneNode(!1);
+
+const pseudoClasses = [
+  "::before",
+  "::after"
+  // '::placeholder', TODO
+];
+const scrollbarPseudoClasses = [
+  "::-webkit-scrollbar",
+  "::-webkit-scrollbar-button",
+  // '::-webkit-scrollbar:horizontal', TODO
+  "::-webkit-scrollbar-thumb",
+  "::-webkit-scrollbar-track",
+  "::-webkit-scrollbar-track-piece",
+  // '::-webkit-scrollbar:vertical', TODO
+  "::-webkit-scrollbar-corner",
+  "::-webkit-resizer"
+];
+function copyPseudoClass(node, cloned, copyScrollbar, context, addWordToFontFamilies) {
+  const { ownerWindow, svgStyleElement, svgStyles, currentNodeStyle } = context;
+  if (!svgStyleElement || !ownerWindow)
+    return;
+  function copyBy(pseudoClass) {
+    const computedStyle = ownerWindow.getComputedStyle(node, pseudoClass);
+    let content = computedStyle.getPropertyValue("content");
+    if (!content || content === "none")
+      return;
+    addWordToFontFamilies?.(content);
+    content = content.replace(/(')|(")|(counter\(.+\))/g, "");
+    const klasses = [uuid()];
+    const defaultStyle = getDefaultStyle(node, pseudoClass, context);
+    currentNodeStyle?.forEach((_, key) => {
+      defaultStyle.delete(key);
+    });
+    const style = getDiffStyle(computedStyle, defaultStyle, context.includeStyleProperties);
+    style.delete("content");
+    style.delete("-webkit-locale");
+    if (style.get("background-clip")?.[0] === "text") {
+      cloned.classList.add("______background-clip--text");
+    }
+    const cloneStyle = [
+      `content: '${content}';`
+    ];
+    style.forEach(([value, priority], name) => {
+      cloneStyle.push(`${name}: ${value}${priority ? " !important" : ""};`);
+    });
+    if (cloneStyle.length === 1)
+      return;
+    try {
+      cloned.className = [cloned.className, ...klasses].join(" ");
+    } catch (err) {
+      context.log.warn("Failed to copyPseudoClass", err);
+      return;
+    }
+    const cssText = cloneStyle.join("\n  ");
+    let allClasses = svgStyles.get(cssText);
+    if (!allClasses) {
+      allClasses = [];
+      svgStyles.set(cssText, allClasses);
+    }
+    allClasses.push(`.${klasses[0]}${pseudoClass}`);
+  }
+  pseudoClasses.forEach(copyBy);
+  if (copyScrollbar)
+    scrollbarPseudoClasses.forEach(copyBy);
 }
-const oe = /* @__PURE__ */ new Set([
+
+const excludeParentNodes = /* @__PURE__ */ new Set([
   "symbol"
   // test/fixtures/svg.symbol.html
 ]);
-function ae(e, t, r) {
-  return S(this, null, function* () {
-    A(t) && (Ze(t) || et(t)) || r.filter && !r.filter(t) || (oe.has(e.nodeName) || oe.has(t.nodeName) ? r.currentParentNodeStyle = void 0 : r.currentParentNodeStyle = r.currentNodeStyle, e.appendChild(yield q(t, r)));
-  });
+async function appendChildNode(node, cloned, child, context, addWordToFontFamilies) {
+  if (isElementNode(child) && (isStyleElement(child) || isScriptElement(child)))
+    return;
+  if (context.filter && !context.filter(child))
+    return;
+  if (excludeParentNodes.has(cloned.nodeName) || excludeParentNodes.has(child.nodeName)) {
+    context.currentParentNodeStyle = void 0;
+  } else {
+    context.currentParentNodeStyle = context.currentNodeStyle;
+  }
+  const childCloned = await cloneNode(child, context, false, addWordToFontFamilies);
+  if (context.isEnable("restoreScrollPosition")) {
+    restoreScrollPosition(node, childCloned);
+  }
+  cloned.appendChild(childCloned);
 }
-function se(e, t, r) {
-  return S(this, null, function* () {
-    var a, s;
-    const n = (s = A(e) ? (a = e.shadowRoot) == null ? void 0 : a.firstChild : void 0) != null ? s : e.firstChild;
-    for (let o = n; o; o = o.nextSibling)
-      if (!Ye(o))
-        if (A(o) && rt(o) && typeof o.assignedNodes == "function") {
-          const i = o.assignedNodes();
-          for (let l = 0; l < i.length; l++)
-            yield ae(t, i[l], r);
-        } else
-          yield ae(t, o, r);
-  });
+async function cloneChildNodes(node, cloned, context, addWordToFontFamilies) {
+  let firstChild = node.firstChild;
+  if (isElementNode(node)) {
+    if (node.shadowRoot) {
+      firstChild = node.shadowRoot?.firstChild;
+      context.shadowRoots.push(node.shadowRoot);
+    }
+  }
+  for (let child = firstChild; child; child = child.nextSibling) {
+    if (isCommentNode(child))
+      continue;
+    if (isElementNode(child) && isSlotElement(child) && typeof child.assignedNodes === "function") {
+      const nodes = child.assignedNodes();
+      for (let i = 0; i < nodes.length; i++) {
+        await appendChildNode(node, cloned, nodes[i], context, addWordToFontFamilies);
+      }
+    } else {
+      await appendChildNode(node, cloned, child, context, addWordToFontFamilies);
+    }
+  }
 }
-function kt(e, t) {
-  const { backgroundColor: r, width: n, height: a, style: s } = t, o = e.style;
-  if (r && o.setProperty("background-color", r, "important"), n && o.setProperty("width", `${n}px`, "important"), a && o.setProperty("height", `${a}px`, "important"), s)
-    for (const i in s)
-      o[i] = s[i];
+function restoreScrollPosition(node, chlidCloned) {
+  if (!isHTMLElementNode(node) || !isHTMLElementNode(chlidCloned))
+    return;
+  const { scrollTop, scrollLeft } = node;
+  if (!scrollTop && !scrollLeft) {
+    return;
+  }
+  const { transform } = chlidCloned.style;
+  const matrix = new DOMMatrix(transform);
+  const { a, b, c, d } = matrix;
+  matrix.a = 1;
+  matrix.b = 0;
+  matrix.c = 0;
+  matrix.d = 1;
+  matrix.translateSelf(-scrollLeft, -scrollTop);
+  matrix.a = a;
+  matrix.b = b;
+  matrix.c = c;
+  matrix.d = d;
+  chlidCloned.style.transform = matrix.toString();
 }
-const Rt = /^[\w-:]+$/;
-function q(e, t, r = !1) {
-  return S(this, null, function* () {
-    var i, l, u, c;
-    const { ownerDocument: n, ownerWindow: a, fontFamilies: s } = t;
-    if (n && Je(e))
-      return n.createTextNode(e.data);
-    if (n && a && A(e) && (G(e) || U(e))) {
-      const f = yield xt(e, t);
-      if (t.isEnable("removeAbnormalAttributes")) {
-        const h = f.getAttributeNames();
-        for (let w = h.length, y = 0; y < w; y++) {
-          const m = h[y];
-          Rt.test(m) || f.removeAttribute(m);
+function applyCssStyleWithOptions(cloned, context) {
+  const { backgroundColor, width, height, style: styles } = context;
+  const clonedStyle = cloned.style;
+  if (backgroundColor)
+    clonedStyle.setProperty("background-color", backgroundColor, "important");
+  if (width)
+    clonedStyle.setProperty("width", `${width}px`, "important");
+  if (height)
+    clonedStyle.setProperty("height", `${height}px`, "important");
+  if (styles) {
+    for (const name in styles) clonedStyle[name] = styles[name];
+  }
+}
+const NORMAL_ATTRIBUTE_RE = /^[\w-:]+$/;
+async function cloneNode(node, context, isRoot = false, addWordToFontFamilies) {
+  const { ownerDocument, ownerWindow, fontFamilies, onCloneEachNode } = context;
+  if (ownerDocument && isTextNode(node)) {
+    if (addWordToFontFamilies && /\S/.test(node.data)) {
+      addWordToFontFamilies(node.data);
+    }
+    return ownerDocument.createTextNode(node.data);
+  }
+  if (ownerDocument && ownerWindow && isElementNode(node) && (isHTMLElementNode(node) || isSVGElementNode(node))) {
+    const cloned2 = await cloneElement(node, context);
+    if (context.isEnable("removeAbnormalAttributes")) {
+      const names = cloned2.getAttributeNames();
+      for (let len = names.length, i = 0; i < len; i++) {
+        const name = names[i];
+        if (!NORMAL_ATTRIBUTE_RE.test(name)) {
+          cloned2.removeAttribute(name);
         }
       }
-      const d = t.currentNodeStyle = Tt(e, f, r, t);
-      r && kt(f, t);
-      let g = !1;
-      if (t.isEnable("copyScrollbar")) {
-        const h = [
-          (i = d.get("overflow-x")) == null ? void 0 : i[0],
-          (l = d.get("overflow-y")) == null ? void 0 : l[1]
-        ];
-        g = h.includes("scroll") || (h.includes("auto") || h.includes("overlay")) && (e.scrollHeight > e.clientHeight || e.scrollWidth > e.clientWidth);
+    }
+    const style = context.currentNodeStyle = copyCssStyles(node, cloned2, isRoot, context);
+    if (isRoot)
+      applyCssStyleWithOptions(cloned2, context);
+    let copyScrollbar = false;
+    if (context.isEnable("copyScrollbar")) {
+      const overflow = [
+        style.get("overflow-x")?.[0],
+        style.get("overflow-y")?.[0]
+      ];
+      copyScrollbar = overflow.includes("scroll") || (overflow.includes("auto") || overflow.includes("overlay")) && (node.scrollHeight > node.clientHeight || node.scrollWidth > node.clientWidth);
+    }
+    const textTransform = style.get("text-transform")?.[0];
+    const families = splitFontFamily(style.get("font-family")?.[0]);
+    const addWordToFontFamilies2 = families ? (word) => {
+      if (textTransform === "uppercase") {
+        word = word.toUpperCase();
+      } else if (textTransform === "lowercase") {
+        word = word.toLowerCase();
+      } else if (textTransform === "capitalize") {
+        word = word[0].toUpperCase() + word.substring(1);
       }
-      return Ct(e, f, g, t), vt(e, f), (c = Te((u = d.get("font-family")) == null ? void 0 : u[0])) == null || c.forEach((h) => s.add(h)), M(e) || (yield se(e, f, t)), f;
+      families.forEach((family) => {
+        let fontFamily = fontFamilies.get(family);
+        if (!fontFamily) {
+          fontFamilies.set(family, fontFamily = /* @__PURE__ */ new Set());
+        }
+        word.split("").forEach((text) => fontFamily.add(text));
+      });
+    } : void 0;
+    copyPseudoClass(
+      node,
+      cloned2,
+      copyScrollbar,
+      context,
+      addWordToFontFamilies2
+    );
+    copyInputValue(node, cloned2);
+    if (!isVideoElement(node)) {
+      await cloneChildNodes(
+        node,
+        cloned2,
+        context,
+        addWordToFontFamilies2
+      );
     }
-    const o = e.cloneNode(!1);
-    return yield se(e, o, t), o;
-  });
-}
-function Dt(e) {
-  if (e.ownerDocument = void 0, e.ownerWindow = void 0, e.svgStyleElement = void 0, e.svgDefsElement = void 0, e.svgStyles.clear(), e.defaultComputedStyles.clear(), e.sandbox) {
-    try {
-      e.sandbox.remove();
-    } catch (t) {
-    }
-    e.sandbox = void 0;
+    await onCloneEachNode?.(cloned2);
+    return cloned2;
   }
-  e.workers = [], e.fontFamilies.clear(), e.fontCssTexts.clear(), e.requests.clear(), e.tasks = [];
+  const cloned = node.cloneNode(false);
+  await cloneChildNodes(node, cloned, context);
+  await onCloneEachNode?.(cloned);
+  return cloned;
 }
-function Ft(e) {
-  const i = e, { url: t, timeout: r, responseType: n } = i, a = re(i, ["url", "timeout", "responseType"]), s = new AbortController(), o = r ? setTimeout(() => s.abort(), r) : void 0;
-  return fetch(t, T({ signal: s.signal }, a)).then((l) => {
-    if (!l.ok)
-      throw new Error("Failed fetch, not 2xx response", { cause: l });
-    switch (n) {
+
+function destroyContext(context) {
+  context.ownerDocument = void 0;
+  context.ownerWindow = void 0;
+  context.svgStyleElement = void 0;
+  context.svgDefsElement = void 0;
+  context.svgStyles.clear();
+  context.defaultComputedStyles.clear();
+  if (context.sandbox) {
+    try {
+      context.sandbox.remove();
+    } catch (err) {
+      context.log.warn("Failed to destroyContext", err);
+    }
+    context.sandbox = void 0;
+  }
+  context.workers = [];
+  context.fontFamilies.clear();
+  context.fontCssTexts.clear();
+  context.requests.clear();
+  context.tasks = [];
+  context.shadowRoots = [];
+}
+
+function baseFetch(options) {
+  const { url, timeout, responseType, ...requestInit } = options;
+  const controller = new AbortController();
+  const timer = timeout ? setTimeout(() => controller.abort(), timeout) : void 0;
+  return fetch(url, { signal: controller.signal, ...requestInit }).then((response) => {
+    if (!response.ok) {
+      throw new Error("Failed fetch, not 2xx response", { cause: response });
+    }
+    switch (responseType) {
+      case "arrayBuffer":
+        return response.arrayBuffer();
       case "dataUrl":
-        return l.blob().then(lt);
+        return response.blob().then(blobToDataUrl);
       case "text":
       default:
-        return l.text();
+        return response.text();
     }
-  }).finally(() => clearTimeout(o));
+  }).finally(() => clearTimeout(timer));
 }
-function _(e, t) {
-  const { url: r, requestType: n = "text", responseType: a = "text", imageDom: s } = t;
-  let o = r;
+function contextFetch(context, options) {
+  const { url: rawUrl, requestType = "text", responseType = "text", imageDom } = options;
+  let url = rawUrl;
   const {
-    timeout: i,
-    acceptOfImage: l,
-    requests: u,
-    fetchFn: c,
+    timeout,
+    acceptOfImage,
+    requests,
+    fetchFn,
     fetch: {
-      requestInit: f,
-      bypassingCache: d,
-      placeholderImage: g
+      requestInit,
+      bypassingCache,
+      placeholderImage
     },
-    workers: h
-  } = e;
-  n === "image" && (L || X) && e.drawImageCount++;
-  let w = u.get(r);
-  if (!w) {
-    d && d instanceof RegExp && d.test(o) && (o += (/\?/.test(o) ? "&" : "?") + new Date().getTime());
-    const y = T({
-      url: o,
-      timeout: i,
-      responseType: a,
-      headers: n === "image" ? { accept: l } : void 0
-    }, f);
-    w = {
-      type: n,
+    font,
+    workers,
+    fontFamilies
+  } = context;
+  if (requestType === "image" && (IN_SAFARI || IN_FIREFOX)) {
+    context.drawImageCount++;
+  }
+  let request = requests.get(rawUrl);
+  if (!request) {
+    if (bypassingCache) {
+      if (bypassingCache instanceof RegExp && bypassingCache.test(url)) {
+        url += (/\?/.test(url) ? "&" : "?") + (/* @__PURE__ */ new Date()).getTime();
+      }
+    }
+    const canFontMinify = requestType.startsWith("font") && font && font.minify;
+    const fontTexts = /* @__PURE__ */ new Set();
+    if (canFontMinify) {
+      const families = requestType.split(";")[1].split(",");
+      families.forEach((family) => {
+        if (!fontFamilies.has(family))
+          return;
+        fontFamilies.get(family).forEach((text) => fontTexts.add(text));
+      });
+    }
+    const needFontMinify = canFontMinify && fontTexts.size;
+    const baseFetchOptions = {
+      url,
+      timeout,
+      responseType: needFontMinify ? "arrayBuffer" : responseType,
+      headers: requestType === "image" ? { accept: acceptOfImage } : void 0,
+      ...requestInit
+    };
+    request = {
+      type: requestType,
       resolve: void 0,
       reject: void 0,
       response: null
-    }, w.response = (() => S(this, null, function* () {
-      if (c && n === "image") {
-        const m = yield c(r);
-        if (m)
-          return m;
+    };
+    request.response = (async () => {
+      if (fetchFn && requestType === "image") {
+        const result = await fetchFn(rawUrl);
+        if (result)
+          return result;
       }
-      return !L && r.startsWith("http") && h.length ? new Promise((m, b) => {
-        h[u.size & h.length - 1].postMessage(T({ rawUrl: r }, y)), w.resolve = m, w.reject = b;
-      }) : Ft(y);
-    }))().catch((m) => {
-      if (u.delete(r), n === "image" && g)
-        return E("Failed to fetch image base64, trying to use placeholder image", o), typeof g == "string" ? g : g(s);
-      throw m;
-    }), u.set(r, w);
-  }
-  return w.response;
-}
-function ke(e, t, r, n) {
-  return S(this, null, function* () {
-    if (!Re(e))
-      return e;
-    for (const [a, s] of _t(e, t))
-      try {
-        const o = yield _(
-          r,
-          {
-            url: s,
-            requestType: n ? "image" : "text",
-            responseType: "dataUrl"
-          }
-        );
-        e = e.replace(Ut(a), `$1${o}$3`);
-      } catch (o) {
-        E("Failed to fetch css data url", a, o);
-      }
-    return e;
-  });
-}
-function Re(e) {
-  return /url\((['"]?)([^'"]+?)\1\)/.test(e);
-}
-const De = /url\((['"]?)([^'"]+?)\1\)/g;
-function _t(e, t) {
-  const r = [];
-  return e.replace(De, (n, a, s) => (r.push([s, be(s, t)]), n)), r.filter(([n]) => !V(n));
-}
-function Ut(e) {
-  const t = e.replace(/([.*+?^${}()|\[\]\/\\])/g, "\\$1");
-  return new RegExp(`(url\\(['"]?)(${t})(['"]?\\))`, "g");
-}
-function Pt(e, t) {
-  return S(this, null, function* () {
-    const {
-      ownerDocument: r,
-      svgStyleElement: n,
-      fontFamilies: a,
-      fontCssTexts: s,
-      tasks: o,
-      font: i
-    } = t;
-    if (!(!r || !n || !a.size))
-      if (i && i.cssText) {
-        const l = ce(i.cssText, t);
-        n.appendChild(r.createTextNode(`${l}
-`));
-      } else {
-        const l = Array.from(r.styleSheets).filter((c) => {
-          try {
-            return "cssRules" in c && Boolean(c.cssRules.length);
-          } catch (f) {
-            return E(`Error while reading CSS rules from ${c.href}`, f), !1;
-          }
-        });
-        yield Promise.all(
-          l.flatMap((c) => Array.from(c.cssRules).map((f, d) => S(this, null, function* () {
-            if (Xe(f)) {
-              let g = d + 1;
-              const h = f.href;
-              let w = "";
-              try {
-                w = yield _(t, {
-                  url: h,
-                  requestType: "text",
-                  responseType: "text"
-                });
-              } catch (m) {
-                E(`Error fetch remote css import from ${h}`, m);
-              }
-              const y = w.replace(
-                De,
-                (m, b, p) => m.replace(p, be(p, h))
-              );
-              for (const m of Bt(y))
-                try {
-                  c.insertRule(
-                    m,
-                    m.startsWith("@import") ? g += 1 : c.cssRules.length
-                  );
-                } catch (b) {
-                  E("Error inserting rule from remote css import", { rule: m, error: b });
-                }
-            }
-          })))
-        ), l.flatMap((c) => Array.from(c.cssRules)).filter((c) => {
-          var f;
-          return ze(c) && Re(c.style.getPropertyValue("src")) && ((f = Te(c.style.getPropertyValue("font-family"))) == null ? void 0 : f.some((d) => a.has(d)));
-        }).forEach((c) => {
-          const f = c, d = s.get(f.cssText);
-          d ? n.appendChild(r.createTextNode(`${d}
-`)) : o.push(
-            ke(
-              f.cssText,
-              f.parentStyleSheet ? f.parentStyleSheet.href : null,
-              t
-            ).then((g) => {
-              g = ce(g, t), s.set(f.cssText, g), n.appendChild(r.createTextNode(`${g}
-`));
-            })
-          );
+      if (!IN_SAFARI && rawUrl.startsWith("http") && workers.length) {
+        return new Promise((resolve, reject) => {
+          const worker = workers[requests.size & workers.length - 1];
+          worker.postMessage({ rawUrl, ...baseFetchOptions });
+          request.resolve = resolve;
+          request.reject = reject;
         });
       }
-  });
-}
-const $t = /(\/\*[\s\S]*?\*\/)/gi, ie = /((@.*?keyframes [\s\S]*?){([\s\S]*?}\s*?)})/gi;
-function Bt(e) {
-  if (e == null)
-    return [];
-  const t = [];
-  let r = e.replace($t, "");
-  for (; ; ) {
-    const s = ie.exec(r);
-    if (!s)
-      break;
-    t.push(s[0]);
+      return baseFetch(baseFetchOptions);
+    })().catch((error) => {
+      requests.delete(rawUrl);
+      if (requestType === "image" && placeholderImage) {
+        context.log.warn("Failed to fetch image base64, trying to use placeholder image", url);
+        return typeof placeholderImage === "string" ? placeholderImage : placeholderImage(imageDom);
+      }
+      throw error;
+    });
+    requests.set(rawUrl, request);
   }
-  r = r.replace(ie, "");
-  const n = /@import[\s\S]*?url\([^)]*\)[\s\S]*?;/gi, a = new RegExp(
-    "((\\s*?(?:\\/\\*[\\s\\S]*?\\*\\/)?\\s*?@media[\\s\\S]*?){([\\s\\S]*?)}\\s*?})|(([\\s\\S]*?){([\\s\\S]*?)})",
-    "gi"
-  );
-  for (; ; ) {
-    let s = n.exec(r);
-    if (s)
-      a.lastIndex = n.lastIndex;
-    else if (s = a.exec(r), s)
-      n.lastIndex = a.lastIndex;
-    else
-      break;
-    t.push(s[0]);
-  }
-  return t;
+  return request.response;
 }
-const Lt = /url\([^)]+\)\s*format\((["']?)([^"']+)\1\)/g, Mt = /src:\s*(?:url\([^)]+\)\s*format\([^)]+\)[,;]\s*)+/g;
-function ce(e, t) {
-  const { font: r } = t, n = r ? r == null ? void 0 : r.preferredFormat : void 0;
-  return n ? e.replace(Mt, (a) => {
-    for (; ; ) {
-      const [s, , o] = Lt.exec(a) || [];
-      if (!o)
-        return "";
-      if (o === n)
-        return `src: ${s};`;
-    }
-  }) : e;
-}
-function Ot(e, t) {
-  if (D(e)) {
-    const r = e.currentSrc || e.src;
-    if (!V(r))
-      return [
-        _(t, {
-          url: r,
-          imageDom: e,
-          requestType: "image",
+
+async function replaceCssUrlToDataUrl(cssText, baseUrl, context, isImage) {
+  if (!hasCssUrl(cssText))
+    return cssText;
+  for (const [rawUrl, url] of parseCssUrls(cssText, baseUrl)) {
+    try {
+      const dataUrl = await contextFetch(
+        context,
+        {
+          url,
+          requestType: isImage ? "image" : "text",
           responseType: "dataUrl"
-        }).then((n) => {
-          n && (e.srcset = "", e.dataset.originalSrc = r, e.src = n || "");
-        })
-      ];
-    (L || X) && t.drawImageCount++;
-  } else if (U(e) && !V(e.href.baseVal)) {
-    const r = e.href.baseVal;
-    return [
-      _(t, {
-        url: r,
-        imageDom: e,
-        requestType: "image",
-        responseType: "dataUrl"
-      }).then((n) => {
-        n && (e.dataset.originalSrc = r, e.href.baseVal = n || "");
-      })
-    ];
+        }
+      );
+      cssText = cssText.replace(toRE(rawUrl), `$1${dataUrl}$3`);
+    } catch (error) {
+      context.log.warn("Failed to fetch css data url", rawUrl, error);
+    }
   }
-  return [];
+  return cssText;
 }
-const Wt = [
+function hasCssUrl(cssText) {
+  return /url\((['"]?)([^'"]+?)\1\)/.test(cssText);
+}
+const URL_RE = /url\((['"]?)([^'"]+?)\1\)/g;
+function parseCssUrls(cssText, baseUrl) {
+  const result = [];
+  cssText.replace(URL_RE, (raw, quotation, url) => {
+    result.push([url, resolveUrl(url, baseUrl)]);
+    return raw;
+  });
+  return result.filter(([url]) => !isDataUrl(url));
+}
+function toRE(url) {
+  const escaped = url.replace(/([.*+?^${}()|\[\]\/\\])/g, "\\$1");
+  return new RegExp(`(url\\(['"]?)(${escaped})(['"]?\\))`, "g");
+}
+
+const properties = [
   "background-image",
   "border-image-source",
   "-webkit-border-image",
   "-webkit-mask-image",
   "list-style-image"
 ];
-function qt(e, t) {
-  return Wt.map((r) => {
-    const n = e.getPropertyValue(r);
-    return !n || n === "none" ? null : ((L || X) && t.drawImageCount++, ke(n, null, t, !0).then((a) => {
-      !a || n === a || e.setProperty(
-        r,
-        a,
-        e.getPropertyPriority(r)
+function embedCssStyleImage(style, context) {
+  return properties.map((property) => {
+    const value = style.getPropertyValue(property);
+    if (!value || value === "none") {
+      return null;
+    }
+    if (IN_SAFARI || IN_FIREFOX) {
+      context.drawImageCount++;
+    }
+    return replaceCssUrlToDataUrl(value, null, context, true).then((newValue) => {
+      if (!newValue || value === newValue)
+        return;
+      style.setProperty(
+        property,
+        newValue,
+        style.getPropertyPriority(property)
       );
-    }));
+    });
   }).filter(Boolean);
 }
-function jt(e, t) {
-  var i;
-  const { ownerDocument: r, svgDefsElement: n } = t, a = (i = e.getAttribute("href")) != null ? i : e.getAttribute("xlink:href");
-  if (!a)
-    return [];
-  const [s, o] = a.split("#");
-  if (o) {
-    const l = `#${o}`, u = r == null ? void 0 : r.querySelector(`svg ${l}`);
-    if (s && e.setAttribute("href", l), n != null && n.querySelector(l))
-      return [];
-    if (u)
+
+function embedImageElement(cloned, context) {
+  if (isImageElement(cloned)) {
+    const originalSrc = cloned.currentSrc || cloned.src;
+    if (!isDataUrl(originalSrc)) {
       return [
-        q(u, t).then((c) => {
-          n != null && n.querySelector(l) || n == null || n.appendChild(c);
+        contextFetch(context, {
+          url: originalSrc,
+          imageDom: cloned,
+          requestType: "image",
+          responseType: "dataUrl"
+        }).then((url) => {
+          if (!url)
+            return;
+          cloned.srcset = "";
+          cloned.dataset.originalSrc = originalSrc;
+          cloned.src = url || "";
         })
       ];
-    if (s)
-      return [
-        _(t, {
-          url: s,
-          responseType: "text"
-        }).then((c) => {
-          n == null || n.insertAdjacentHTML("beforeend", c);
-        })
-      ];
+    }
+    if (IN_SAFARI || IN_FIREFOX) {
+      context.drawImageCount++;
+    }
+  } else if (isSVGElementNode(cloned) && !isDataUrl(cloned.href.baseVal)) {
+    const originalSrc = cloned.href.baseVal;
+    return [
+      contextFetch(context, {
+        url: originalSrc,
+        imageDom: cloned,
+        requestType: "image",
+        responseType: "dataUrl"
+      }).then((url) => {
+        if (!url)
+          return;
+        cloned.dataset.originalSrc = originalSrc;
+        cloned.href.baseVal = url || "";
+      })
+    ];
   }
   return [];
 }
-function Fe(e, t) {
-  const { tasks: r } = t;
-  A(e) && ((D(e) || ye(e)) && r.push(...Ot(e, t)), Ge(e) && r.push(...jt(e, t))), G(e) && r.push(...qt(e.style, t)), e.childNodes.forEach((n) => {
-    Fe(n, t);
+
+function embedSvgUse(cloned, context) {
+  const { ownerDocument, svgDefsElement } = context;
+  const href = cloned.getAttribute("href") ?? cloned.getAttribute("xlink:href");
+  if (!href)
+    return [];
+  const [svgUrl, id] = href.split("#");
+  if (id) {
+    const query = `#${id}`;
+    const definition = context.shadowRoots.reduce(
+      (res, root) => {
+        return res ?? root.querySelector(`svg ${query}`);
+      },
+      ownerDocument?.querySelector(`svg ${query}`)
+    );
+    if (svgUrl) {
+      cloned.setAttribute("href", query);
+    }
+    if (svgDefsElement?.querySelector(query))
+      return [];
+    if (definition) {
+      svgDefsElement?.appendChild(definition.cloneNode(true));
+      return [];
+    } else if (svgUrl) {
+      return [
+        contextFetch(context, {
+          url: svgUrl,
+          responseType: "text"
+        }).then((svgData) => {
+          svgDefsElement?.insertAdjacentHTML("beforeend", svgData);
+        })
+      ];
+    }
+  }
+  return [];
+}
+
+function embedNode(cloned, context) {
+  const { tasks } = context;
+  if (isElementNode(cloned)) {
+    if (isImageElement(cloned) || isSVGImageElementNode(cloned)) {
+      tasks.push(...embedImageElement(cloned, context));
+    }
+    if (isSVGUseElementNode(cloned)) {
+      tasks.push(...embedSvgUse(cloned, context));
+    }
+  }
+  if (isHTMLElementNode(cloned)) {
+    tasks.push(...embedCssStyleImage(cloned.style, context));
+  }
+  cloned.childNodes.forEach((child) => {
+    embedNode(child, context);
   });
 }
-function Vt(e, t) {
-  return S(this, null, function* () {
-    const r = yield N(e, t);
-    if (A(r.node) && U(r.node))
-      return r.node;
-    const {
-      ownerDocument: n,
-      log: a,
-      tasks: s,
-      svgStyleElement: o,
-      svgDefsElement: i,
-      svgStyles: l,
-      font: u,
-      progress: c,
-      autoDestruct: f,
-      onCloneNode: d,
-      onEmbedNode: g,
-      onCreateForeignObjectSvg: h
-    } = r;
-    a.time("clone node");
-    const w = yield q(r.node, r, !0);
-    if (o && n) {
-      let C = "";
-      l.forEach((v, I) => {
-        C += `${v.join(`,
-`)} {
-  ${I}
-}
-`;
-      }), o.appendChild(n.createTextNode(C));
-    }
-    a.timeEnd("clone node"), d == null || d(w), u !== !1 && A(w) && (a.time("embed web font"), yield Pt(w, r), a.timeEnd("embed web font")), a.time("embed node"), Fe(w, r);
-    const y = s.length;
-    let m = 0;
-    const b = () => S(this, null, function* () {
-      for (; ; ) {
-        const C = s.pop();
-        if (!C)
-          break;
-        try {
-          yield C;
-        } catch (v) {
-          E("Failed to run task", v);
-        }
-        c == null || c(++m, y);
+
+async function embedWebFont(clone, context) {
+  const {
+    ownerDocument,
+    svgStyleElement,
+    fontFamilies,
+    fontCssTexts,
+    tasks,
+    font
+  } = context;
+  if (!ownerDocument || !svgStyleElement || !fontFamilies.size) {
+    return;
+  }
+  if (font && font.cssText) {
+    const cssText = filterPreferredFormat(font.cssText, context);
+    svgStyleElement.appendChild(ownerDocument.createTextNode(`${cssText}
+`));
+  } else {
+    const styleSheets = Array.from(ownerDocument.styleSheets).filter((styleSheet) => {
+      try {
+        return "cssRules" in styleSheet && Boolean(styleSheet.cssRules.length);
+      } catch (error) {
+        context.log.warn(`Error while reading CSS rules from ${styleSheet.href}`, error);
+        return false;
       }
     });
-    c == null || c(m, y), yield Promise.all([...Array(4)].map(b)), a.timeEnd("embed node"), g == null || g(w);
-    const p = Ht(w, r);
-    return i && p.insertBefore(i, p.children[0]), o && p.insertBefore(o, p.children[0]), f && Dt(r), h == null || h(p), p;
-  });
+    const tempDoc = ownerDocument.implementation.createHTMLDocument("");
+    const tempStyleEl = tempDoc.createElement("style");
+    tempDoc.head.appendChild(tempStyleEl);
+    const tempStyleSheet = tempStyleEl.sheet;
+    await Promise.all(
+      styleSheets.flatMap((styleSheet) => {
+        return Array.from(styleSheet.cssRules).map(async (cssRule) => {
+          if (isCSSImportRule(cssRule)) {
+            const baseUrl = cssRule.href;
+            let cssText = "";
+            try {
+              cssText = await contextFetch(context, {
+                url: baseUrl,
+                requestType: "text",
+                responseType: "text"
+              });
+            } catch (error) {
+              context.log.warn(`Error fetch remote css import from ${baseUrl}`, error);
+            }
+            const replacedCssText = cssText.replace(
+              URL_RE,
+              (raw, quotation, url) => raw.replace(url, resolveUrl(url, baseUrl))
+            );
+            for (const rule of parseCss(replacedCssText)) {
+              try {
+                tempStyleSheet.insertRule(rule, tempStyleSheet.cssRules.length);
+              } catch (error) {
+                context.log.warn("Error inserting rule from remote css import", { rule, error });
+              }
+            }
+          }
+        });
+      })
+    );
+    if (tempStyleSheet.cssRules.length)
+      styleSheets.push(tempStyleSheet);
+    const cssRules = [];
+    styleSheets.forEach((sheet) => {
+      unwrapCssLayers(sheet.cssRules, cssRules);
+    });
+    cssRules.filter((cssRule) => isCssFontFaceRule(cssRule) && hasCssUrl(cssRule.style.getPropertyValue("src")) && splitFontFamily(cssRule.style.getPropertyValue("font-family"))?.some((val) => fontFamilies.has(val))).forEach((value) => {
+      const rule = value;
+      const cssText = fontCssTexts.get(rule.cssText);
+      if (cssText) {
+        svgStyleElement.appendChild(ownerDocument.createTextNode(`${cssText}
+`));
+      } else {
+        tasks.push(
+          replaceCssUrlToDataUrl(
+            rule.cssText,
+            rule.parentStyleSheet ? rule.parentStyleSheet.href : null,
+            context
+          ).then((cssText2) => {
+            cssText2 = filterPreferredFormat(cssText2, context);
+            fontCssTexts.set(rule.cssText, cssText2);
+            svgStyleElement.appendChild(ownerDocument.createTextNode(`${cssText2}
+`));
+          })
+        );
+      }
+    });
+  }
 }
-function Ht(e, t) {
-  const { width: r, height: n } = t, a = Se(r, n, e.ownerDocument), s = a.ownerDocument.createElementNS(a.namespaceURI, "foreignObject");
-  return s.setAttributeNS(null, "x", "0%"), s.setAttributeNS(null, "y", "0%"), s.setAttributeNS(null, "width", "100%"), s.setAttributeNS(null, "height", "100%"), s.append(e), a.appendChild(s), a;
-}
-function Y(e, t) {
-  return S(this, null, function* () {
-    var o;
-    const r = yield N(e, t), n = yield Vt(r), a = Ee(n, r.isEnable("removeControlCharacter"));
-    r.autoDestruct || (r.svgStyleElement = Ae(r.ownerDocument), r.svgDefsElement = (o = r.ownerDocument) == null ? void 0 : o.createElementNS(W, "defs"), r.svgStyles.clear());
-    const s = k(a, n.ownerDocument);
-    return yield wt(s, r);
-  });
-}
-function Gt(e, t) {
-  return S(this, null, function* () {
-    const r = yield N(e, t), { log: n, type: a, quality: s, dpi: o } = r, i = yield Y(r);
-    n.time("canvas to blob");
-    const l = yield it(i, a, s);
-    if (["image/png", "image/jpeg"].includes(a) && o) {
-      const u = yield ut(l.slice(0, 33));
-      let c = new Uint8Array(u);
-      return a === "image/png" ? c = he(c, o) : a === "image/jpeg" && (c = ue(c, o)), n.timeEnd("canvas to blob"), new Blob([c, l.slice(33)], { type: a });
+const COMMENTS_RE = /(\/\*[\s\S]*?\*\/)/g;
+const KEYFRAMES_RE = /((@.*?keyframes [\s\S]*?){([\s\S]*?}\s*?)})/gi;
+function parseCss(source) {
+  if (source == null)
+    return [];
+  const result = [];
+  let cssText = source.replace(COMMENTS_RE, "");
+  while (true) {
+    const matches = KEYFRAMES_RE.exec(cssText);
+    if (!matches)
+      break;
+    result.push(matches[0]);
+  }
+  cssText = cssText.replace(KEYFRAMES_RE, "");
+  const IMPORT_RE = /@import[\s\S]*?url\([^)]*\)[\s\S]*?;/gi;
+  const UNIFIED_RE = new RegExp(
+    // eslint-disable-next-line
+    "((\\s*?(?:\\/\\*[\\s\\S]*?\\*\\/)?\\s*?@media[\\s\\S]*?){([\\s\\S]*?)}\\s*?})|(([\\s\\S]*?){([\\s\\S]*?)})",
+    "gi"
+  );
+  while (true) {
+    let matches = IMPORT_RE.exec(cssText);
+    if (!matches) {
+      matches = UNIFIED_RE.exec(cssText);
+      if (!matches) {
+        break;
+      } else {
+        IMPORT_RE.lastIndex = UNIFIED_RE.lastIndex;
+      }
+    } else {
+      UNIFIED_RE.lastIndex = IMPORT_RE.lastIndex;
     }
-    return n.timeEnd("canvas to blob"), l;
-  });
+    result.push(matches[0]);
+  }
+  return result;
 }
-function P(e, t) {
-  return S(this, null, function* () {
-    const r = yield N(e, t), { log: n, quality: a, type: s, dpi: o } = r, i = yield Y(r);
-    n.time("canvas to data url");
-    let l = i.toDataURL(s, a);
-    if (["image/png", "image/jpeg"].includes(s) && o && we && Ve) {
-      const [u, c] = l.split(",");
-      let f = 0, d = !1;
-      if (s === "image/png") {
-        const p = qe(c);
-        p >= 0 ? (f = Math.ceil((p + 28) / 3) * 4, d = !0) : f = 33 / 3 * 4;
-      } else
-        s === "image/jpeg" && (f = 18 / 3 * 4);
-      const g = c.substring(0, f), h = c.substring(f), w = window.atob(g), y = new Uint8Array(w.length);
-      for (let p = 0; p < y.length; p++)
-        y[p] = w.charCodeAt(p);
-      const m = s === "image/png" ? he(y, o, d) : ue(y, o), b = window.btoa(String.fromCharCode(...m));
-      l = [u, ",", b, h].join("");
+const URL_WITH_FORMAT_RE = /url\([^)]+\)\s*format\((["']?)([^"']+)\1\)/g;
+const FONT_SRC_RE = /src:\s*(?:url\([^)]+\)\s*format\([^)]+\)[,;]\s*)+/g;
+function filterPreferredFormat(str, context) {
+  const { font } = context;
+  const preferredFormat = font ? font?.preferredFormat : void 0;
+  return preferredFormat ? str.replace(FONT_SRC_RE, (match) => {
+    while (true) {
+      const [src, , format] = URL_WITH_FORMAT_RE.exec(match) || [];
+      if (!format)
+        return "";
+      if (format === preferredFormat)
+        return `src: ${src};`;
     }
-    return n.timeEnd("canvas to data url"), l;
-  });
+  }) : str;
 }
-function zt(e, t) {
-  return S(this, null, function* () {
-    const r = yield N(e, t), { width: n, height: a, ownerDocument: s } = r, o = yield P(r), i = Se(n, a, s), l = i.ownerDocument.createElementNS(i.namespaceURI, "image");
-    return l.setAttributeNS(null, "href", o), l.setAttributeNS(null, "height", "100%"), l.setAttributeNS(null, "width", "100%"), i.appendChild(l), Ee(i, r.isEnable("removeControlCharacter"));
-  });
+function unwrapCssLayers(rules, out = []) {
+  for (const rule of Array.from(rules)) {
+    if (isLayerBlockRule(rule)) {
+      out.push(...unwrapCssLayers(rule.cssRules));
+    } else if ("cssRules" in rule) {
+      unwrapCssLayers(rule.cssRules, out);
+    } else {
+      out.push(rule);
+    }
+  }
+  return out;
 }
-function Yt(e, t) {
-  return S(this, null, function* () {
-    const r = yield N(e, t), { ownerDocument: n, width: a, height: s, scale: o, type: i } = r, l = i === "image/svg+xml" ? yield zt(r) : yield P(r), u = k(l, n);
-    return u.width = Math.floor(a * o), u.height = Math.floor(s * o), u.style.width = `${a}px`, u.style.height = `${s}px`, u;
-  });
+
+const SVG_EXTERNAL_RESOURCE_REGEX = /\bx?link:?href\s*=\s*["'](?!data:)[^"']+["']/i;
+function svgHasExternalResources(svg) {
+  return SVG_EXTERNAL_RESOURCE_REGEX.test(svg.innerHTML);
 }
-function Jt(e, t) {
-  return S(this, null, function* () {
-    return P(
-      yield N(e, R(T({}, t), { type: "image/jpeg" }))
-    );
-  });
+async function domToForeignObjectSvg(node, options) {
+  const context = await orCreateContext(node, options);
+  if (isElementNode(context.node) && isSVGElementNode(context.node) && !svgHasExternalResources(context.node))
+    return context.node;
+  const {
+    ownerDocument,
+    log,
+    tasks,
+    svgStyleElement,
+    svgDefsElement,
+    svgStyles,
+    font,
+    progress,
+    autoDestruct,
+    onCloneNode,
+    onEmbedNode,
+    onCreateForeignObjectSvg
+  } = context;
+  log.time("clone node");
+  const clone = await cloneNode(context.node, context, true);
+  if (svgStyleElement && ownerDocument) {
+    let allCssText = "";
+    svgStyles.forEach((klasses, cssText) => {
+      allCssText += `${klasses.join(",\n")} {
+  ${cssText}
 }
-function Kt(e, t) {
-  return S(this, null, function* () {
-    const r = yield N(e, t), n = yield Y(r);
-    return n.getContext("2d").getImageData(0, 0, n.width, n.height).data;
-  });
+`;
+    });
+    svgStyleElement.appendChild(ownerDocument.createTextNode(allCssText));
+  }
+  log.timeEnd("clone node");
+  await onCloneNode?.(clone);
+  if (font !== false && isElementNode(clone)) {
+    log.time("embed web font");
+    await embedWebFont(clone, context);
+    log.timeEnd("embed web font");
+  }
+  log.time("embed node");
+  embedNode(clone, context);
+  const count = tasks.length;
+  let current = 0;
+  const runTask = async () => {
+    while (true) {
+      const task = tasks.pop();
+      if (!task)
+        break;
+      try {
+        await task;
+      } catch (error) {
+        context.log.warn("Failed to run task", error);
+      }
+      progress?.(++current, count);
+    }
+  };
+  progress?.(current, count);
+  await Promise.all([...Array.from({ length: 4 })].map(runTask));
+  log.timeEnd("embed node");
+  await onEmbedNode?.(clone);
+  const svg = createForeignObjectSvg(clone, context);
+  svgDefsElement && svg.insertBefore(svgDefsElement, svg.children[0]);
+  svgStyleElement && svg.insertBefore(svgStyleElement, svg.children[0]);
+  autoDestruct && destroyContext(context);
+  await onCreateForeignObjectSvg?.(svg);
+  return svg;
 }
-function Qt(e, t) {
-  return S(this, null, function* () {
-    return P(
-      yield N(e, R(T({}, t), { type: "image/png" }))
-    );
-  });
+function createForeignObjectSvg(clone, context) {
+  const { width, height } = context;
+  const svg = createSvg(width, height, clone.ownerDocument);
+  const foreignObject = svg.ownerDocument.createElementNS(svg.namespaceURI, "foreignObject");
+  foreignObject.setAttributeNS(null, "x", "0%");
+  foreignObject.setAttributeNS(null, "y", "0%");
+  foreignObject.setAttributeNS(null, "width", "100%");
+  foreignObject.setAttributeNS(null, "height", "100%");
+  foreignObject.append(clone);
+  svg.appendChild(foreignObject);
+  return svg;
 }
-function Zt(e, t) {
-  return S(this, null, function* () {
-    return P(
-      yield N(e, R(T({}, t), { type: "image/webp" }))
-    );
-  });
+
+async function domToCanvas(node, options) {
+  const context = await orCreateContext(node, options);
+  const svg = await domToForeignObjectSvg(context);
+  const dataUrl = svgToDataUrl(svg, context.isEnable("removeControlCharacter"));
+  if (!context.autoDestruct) {
+    context.svgStyleElement = createStyleElement(context.ownerDocument);
+    context.svgDefsElement = context.ownerDocument?.createElementNS(XMLNS, "defs");
+    context.svgStyles.clear();
+  }
+  const image = createImage(dataUrl, svg.ownerDocument);
+  return await imageToCanvas(image, context);
 }
+
+async function domToBlob(node, options) {
+  const context = await orCreateContext(node, options);
+  const { log, type, quality, dpi } = context;
+  const canvas = await domToCanvas(context);
+  log.time("canvas to blob");
+  const blob = await canvasToBlob(canvas, type, quality);
+  if (["image/png", "image/jpeg"].includes(type) && dpi) {
+    const arrayBuffer = await blobToArrayBuffer(blob.slice(0, 33));
+    let uint8Array = new Uint8Array(arrayBuffer);
+    if (type === "image/png") {
+      uint8Array = changePngDpi(uint8Array, dpi);
+    } else if (type === "image/jpeg") {
+      uint8Array = changeJpegDpi(uint8Array, dpi);
+    }
+    log.timeEnd("canvas to blob");
+    return new Blob([uint8Array, blob.slice(33)], { type });
+  }
+  log.timeEnd("canvas to blob");
+  return blob;
+}
+
+async function domToDataUrl(node, options) {
+  const context = await orCreateContext(node, options);
+  const { log, quality, type, dpi } = context;
+  const canvas = await domToCanvas(context);
+  log.time("canvas to data url");
+  let dataUrl = canvas.toDataURL(type, quality);
+  if (["image/png", "image/jpeg"].includes(type) && dpi && SUPPORT_ATOB && SUPPORT_BTOA) {
+    const [format, body] = dataUrl.split(",");
+    let headerLength = 0;
+    let overwritepHYs = false;
+    if (type === "image/png") {
+      const b64Index = detectPhysChunkFromDataUrl(body);
+      if (b64Index >= 0) {
+        headerLength = Math.ceil((b64Index + 28) / 3) * 4;
+        overwritepHYs = true;
+      } else {
+        headerLength = 33 / 3 * 4;
+      }
+    } else if (type === "image/jpeg") {
+      headerLength = 18 / 3 * 4;
+    }
+    const stringHeader = body.substring(0, headerLength);
+    const restOfData = body.substring(headerLength);
+    const headerBytes = window.atob(stringHeader);
+    const uint8Array = new Uint8Array(headerBytes.length);
+    for (let i = 0; i < uint8Array.length; i++) {
+      uint8Array[i] = headerBytes.charCodeAt(i);
+    }
+    const finalArray = type === "image/png" ? changePngDpi(uint8Array, dpi, overwritepHYs) : changeJpegDpi(uint8Array, dpi);
+    const base64Header = window.btoa(String.fromCharCode(...finalArray));
+    dataUrl = [format, ",", base64Header, restOfData].join("");
+  }
+  log.timeEnd("canvas to data url");
+  return dataUrl;
+}
+
+async function domToSvg(node, options) {
+  const context = await orCreateContext(node, options);
+  const { width, height, ownerDocument } = context;
+  const dataUrl = await domToDataUrl(context);
+  const svg = createSvg(width, height, ownerDocument);
+  const svgImage = svg.ownerDocument.createElementNS(svg.namespaceURI, "image");
+  svgImage.setAttributeNS(null, "href", dataUrl);
+  svgImage.setAttributeNS(null, "height", "100%");
+  svgImage.setAttributeNS(null, "width", "100%");
+  svg.appendChild(svgImage);
+  return svgToDataUrl(svg, context.isEnable("removeControlCharacter"));
+}
+
+async function domToImage(node, options) {
+  const context = await orCreateContext(node, options);
+  const { ownerDocument, width, height, scale, type } = context;
+  const url = type === "image/svg+xml" ? await domToSvg(context) : await domToDataUrl(context);
+  const image = createImage(url, ownerDocument);
+  image.width = Math.floor(width * scale);
+  image.height = Math.floor(height * scale);
+  image.style.width = `${width}px`;
+  image.style.height = `${height}px`;
+  return image;
+}
+
+async function domToJpeg(node, options) {
+  return domToDataUrl(
+    await orCreateContext(node, { ...options, type: "image/jpeg" })
+  );
+}
+
+async function domToPixel(node, options) {
+  const context = await orCreateContext(node, options);
+  const canvas = await domToCanvas(context);
+  return canvas.getContext("2d").getImageData(0, 0, canvas.width, canvas.height).data;
+}
+
+async function domToPng(node, options) {
+  return domToDataUrl(
+    await orCreateContext(node, { ...options, type: "image/png" })
+  );
+}
+
+async function domToWebp(node, options) {
+  return domToDataUrl(
+    await orCreateContext(node, { ...options, type: "image/webp" })
+  );
+}
+
 
 
 // EXTERNAL MODULE: ./src/core/utils.ts
-var utils = __webpack_require__(465);
-;// CONCATENATED MODULE: ./src/core/parseComments.js
+var utils = __webpack_require__(379);
+;// ./src/core/parseComments.js
 // 在window对象上创建存储空间
 //window.ArticleComments = window.ArticleComments || {};
 
@@ -4562,84 +5043,129 @@ function formatDate(date) {
 }
 
 // EXTERNAL MODULE: ./src/core/obsidianSaver.ts
-var obsidianSaver = __webpack_require__(44);
-;// CONCATENATED MODULE: ./src/index.ts
+var obsidianSaver = __webpack_require__(784);
+// EXTERNAL MODULE: ./src/core/toast.ts
+var toast = __webpack_require__(197);
+;// ./src/index.ts
 
 
 
 
 
 
-/**
- * 适配复杂的想法：转发、带卡片链接、带@
- * 页：推送页，个人/机构主页，回答页，问题页，文章页，想法页，收藏夹页，搜索结果页
- */
+
 // @grant        GM_setValue
 // @grant        GM_getValue
-// @grant    GM_registerMenuCommand
-// @grant    GM_unregisterMenuCommand
+// @grant        GM_registerMenuCommand
+// @grant        GM_unregisterMenuCommand
+// @grant        GM_setClipboard
+const copyToClipboard = (text) => {
+    try {
+        // @ts-ignore
+        if (typeof GM_setClipboard !== "undefined") {
+            // @ts-ignore
+            GM_setClipboard(text, "text");
+            return true;
+        }
+    }
+    catch (e) { }
+    try {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text);
+            return true;
+        }
+    }
+    catch (e) { }
+    try {
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+        return true;
+    }
+    catch (e) { }
+    return false;
+};
 /**
- * 油猴按钮
+ * 油猴按钮 - 保留所有原生设置
  */
 function registerBtn() {
     try {
         // @ts-ignore
-        let skipEmpty = GM_registerMenuCommand("（推荐）解析时跳过空白段落", function () {
+        let uiMode = GM_getValue("ui_mode", "minimal");
+        // @ts-ignore
+        GM_registerMenuCommand(`🎨 UI界面模式：${uiMode === 'minimal' ? '【老版极简居中】(点击切换新版)' : '【新版增强侧边栏】(点击切换老版)'}`, function () {
+            let nextMode = uiMode === 'minimal' ? 'full' : 'minimal';
+            // @ts-ignore
+            GM_setValue("ui_mode", nextMode);
+            alert(`已切换为：${nextMode === 'minimal' ? '老版极简居中 UI' : '新版增强侧边栏 UI'}\n刷新页面后生效。`);
+            location.reload();
+        });
+        // @ts-ignore
+        let sidebarTriggerMode = GM_getValue("sidebar_trigger_mode", "hover_content");
+        // @ts-ignore
+        GM_registerMenuCommand(`🔘 侧边栏展开方式：${sidebarTriggerMode === 'chevron' ? '【Chevron图标触发】(点击切换为【鼠标悬停正文】)' : '【鼠标悬停正文触发(原版)】(点击切换为【Chevron图标】)'}`, function () {
+            let nextMode = sidebarTriggerMode === 'chevron' ? 'hover_content' : 'chevron';
+            // @ts-ignore
+            GM_setValue("sidebar_trigger_mode", nextMode);
+            alert(`已切换为：${nextMode === 'chevron' ? 'Chevron 图标触发模式' : '鼠标悬停正文触发模式 (原版)'}\n刷新页面后生效。`);
+            location.reload();
+        });
+        // @ts-ignore
+        GM_registerMenuCommand("（推荐）解析时跳过空白段落", function () {
             // @ts-ignore
             let ac = GM_getValue("skip_empty_p"), c;
             !ac ? c = confirm("解析时跳过空白段落，避免产生大量多余的换行，你是否继续？") : alert('已取消跳过空白段落');
             if (c) {
                 // @ts-ignore
                 GM_setValue("skip_empty_p", true);
-                // @ts-ignore
             }
             else
                 GM_setValue("skip_empty_p", false);
         });
         // @ts-ignore
-        let menuFM = GM_registerMenuCommand("复制内容时添加fm元信息", function () {
+        GM_registerMenuCommand("复制内容时添加fm元信息", function () {
             // @ts-ignore
             let ac = GM_getValue("copy_save_fm"), c;
             !ac ? c = confirm("复制内容时，添加 frontmatter 信息，就像下载为纯文本的时候一样。你是否继续？") : alert('已取消复制添加fm');
             // @ts-ignore
             c ? GM_setValue("copy_save_fm", true) : GM_setValue("copy_save_fm", false);
-            //alert(GM_getValue("copy_save_fm"))
         });
         // @ts-ignore
-        let menuSaveCM = GM_registerMenuCommand("复制内容时同时复制评论", function () {
+        GM_registerMenuCommand("复制内容时同时复制评论", function () {
             // @ts-ignore
             let ns = GM_getValue("copy_save_cm"), c;
             !ns ? c = confirm("启用后，复制时也会复制评论，就像直接复制了下载的纯文本。你是否继续？") : alert('已取消复制评论');
             // @ts-ignore
             c ? GM_setValue("copy_save_cm", true) : GM_setValue("copy_save_cm", false);
-            //alert(GM_getValue("copy_save_cm"))
         });
         // @ts-ignore
-        let menuMergeCM = GM_registerMenuCommand("下载zip时合并正文与评论", function () {
+        GM_registerMenuCommand("下载zip时合并正文与评论", function () {
             // @ts-ignore
             let ns = GM_getValue("zip_merge_cm"), c;
             !ns ? c = confirm("启用后，下载zip时会合并正文与评论到一个文件中。你是否继续？") : alert('已取消合并');
             // @ts-ignore
             c ? GM_setValue("zip_merge_cm", true) : GM_setValue("zip_merge_cm", false);
-            //alert(GM_getValue("zip_merge_cm"))
         });
         // @ts-ignore
-        let menuSaveImg = GM_registerMenuCommand("复制与下载纯文本时不保存图片", function () {
+        GM_registerMenuCommand("复制与下载纯文本时不保存图片", function () {
             // @ts-ignore
             let ns = GM_getValue("no_save_img"), c;
             !ns ? c = confirm("启用后，复制、存文本时将所有图片替换为“[图片]”，不影响存zip。你是否继续？") : alert('已取消不存图');
             // @ts-ignore
             c ? GM_setValue("no_save_img", true) : GM_setValue("no_save_img", false);
-            //alert(GM_getValue("no_save_img"))
         });
         // @ts-ignore
-        let menuFilename = GM_registerMenuCommand("自定义保存后的文件名格式", function () {
+        GM_registerMenuCommand("自定义保存后的文件名格式", function () {
             // @ts-ignore
             let efm = GM_getValue("edit_Filename");
             let fm = prompt(`是否自定义保存后的文件名格式？留空或填错恢复默认\n默认为title + "_" + author.name + "_" + time.modified.slice(0, 10) + remark，你可以调整它的顺序，使用其他属性需要阅读源码\n(new Date).toLocaleDateString().replaceAll('/','-')添加保存日期`, efm ? efm : 'title + "_" + author.name + "_" + time.modified.slice(0, 10) + remark');
             // @ts-ignore
             GM_setValue("edit_Filename", fm);
-            //alert(GM_getValue("edit_Filename"))
         });
     }
     catch (e) {
@@ -4647,9 +5173,54 @@ function registerBtn() {
     }
 }
 registerBtn();
-const ButtonContainer = document.createElement("div");
-ButtonContainer.classList.add("zhihubackup-wrap");
-ButtonContainer.innerHTML = `<div class="zhihubackup-container">
+const getUIMode = () => {
+    try {
+        // @ts-ignore
+        return GM_getValue("ui_mode", "minimal");
+    }
+    catch (e) {
+        return "minimal";
+    }
+};
+const getSidebarTriggerMode = () => {
+    try {
+        // @ts-ignore
+        return GM_getValue("sidebar_trigger_mode", "hover_content");
+    }
+    catch (e) {
+        return "hover_content";
+    }
+};
+const renderContainerHTML = () => {
+    const isMinimal = getUIMode() === 'minimal';
+    if (isMinimal) {
+        return `<div class="zhcollect-minimal-btns">
+    <button class="to-copy-context zhcollect-btn" style="border-radius:1em 0 0 1em;padding-left:.4em;">复制标题+正文</button>
+    <button class="to-copy-content zhcollect-btn" style="border-radius:0 1em 1em 0;padding-right:.4em;">复制正文</button>
+</div>`;
+    }
+    const isChevronMode = getSidebarTriggerMode() === 'chevron';
+    if (isChevronMode) {
+        return `<div class="zhihubackup-sticky-box">
+    <div class="zhihubackup-container">
+        <button class="to-copy Button VoteButton">复制为Markdown</button>
+        <button class="to-zip Button VoteButton">下载为 ZIP</button>
+        <button class="to-text Button VoteButton">下载为纯文本</button>
+        <button class="to-png Button VoteButton">剪藏为 PNG</button>
+        <button class="to-obsidian Button VoteButton">
+        <svg style="width: 2em;height: 2em;width: 1.5em;height: 1.5em;opacity: 0.6;vertical-align: sub;" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M19.355 18.538a68.967 68.959 0 0 0 1.858-2.954a.81.81 0 0 0-.062-.9c-.516-.685-1.504-2.075-2.042-3.362c-.553-1.321-.636-3.375-.64-4.377a1.7 1.7 0 0 0-.358-1.05l-3.198-4.064a4 4 0 0 1-.076.543c-.106.503-.307 1.004-.536 1.5c-.134.29-.29.6-.446.914l-.31.626c-.516 1.068-.997 2.227-1.132 3.59c-.124 1.26.046 2.73.815 4.481q.192.016.386.044a6.36 6.36 0 0 1 3.326 1.505c.916.79 1.744 1.922 2.415 3.5zM8.199 22.569q.11.019.22.02c.78.024 2.095.092 3.16.29c.87.16 2.593.64 4.01 1.055c1.083.316 2.198-.548 2.355-1.664c.114-.814.33-1.735.725-2.58l-.01.005c-.67-1.87-1.522-3.078-2.416-3.849a5.3 5.3 0 0 0-2.778-1.257c-1.54-.216-2.952.19-3.84.45c.532 2.218.368 4.829-1.425 7.531zM5.533 9.938q-.035.15-.098.29L2.82 16.059a1.6 1.6 0 0 0 .313 1.772l4.116 4.24c2.103-3.101 1.796-6.02.836-8.3c-.728-1.73-1.832-3.081-2.55-3.831zM9.32 14.01c.615-.183 1.606-.465 2.745-.534c-.683-1.725-.848-3.233-.716-4.577c.154-1.552.7-2.847 1.235-3.95q.17-.35.328-.664c.149-.297.288-.577.419-.86c.217-.47.379-.885.46-1.27c.08-.38.08-.72-.014-1.043c-.095-.325-.297-.675-.68-1.06a1.6 1.6 0 0 0-1.475.36l-4.95 4.452a1.6 1.6 0 0 0-.513.952l-.427 2.83c.672.59 2.328 2.316 3.335 4.711q.136.317.253.653"></path></svg>
+        保存到<br>指定文件夹</button>
+        <div class="Button VoteButton" style="display: inline-block;box-sizing: border-box;overflow: hidden;">
+            <textarea class="to-remark" type="text" placeholder="添加备注" style="width: 100%;" maxlength="60"></textarea>
+        </div>
+        <div class="Button VoteButton" style="display: inline-block;box-sizing: border-box;">
+            <label><input type="checkbox" checked class="to-cm"> 保存评论</label>
+        </div>
+    </div>
+    <div class="zhihubackup-trigger" title="展开工具栏"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg></div>
+</div>`;
+    }
+    return `<div class="zhihubackup-container">
     <button class="to-copy Button VoteButton">复制为Markdown</button>
     <button class="to-zip Button VoteButton">下载为 ZIP</button>
     <button class="to-text Button VoteButton">下载为纯文本</button>
@@ -4662,294 +5233,377 @@ ButtonContainer.innerHTML = `<div class="zhihubackup-container">
     </div>
     <div class="Button VoteButton" style="display: inline-block;box-sizing: border-box;">
         <label><input type="checkbox" checked class="to-cm"> 保存评论</label>
-    </div>`;
+    </div>
+</div>`;
+};
+const ButtonContainer = document.createElement("div");
+if (getUIMode() === 'full') {
+    ButtonContainer.classList.add("zhihubackup-wrap");
+}
+ButtonContainer.innerHTML = renderContainerHTML();
+function throttle(func, wait = 1000) {
+    let timer = null;
+    return function (...args) {
+        if (!timer) {
+            func.apply(this, args);
+            timer = setTimeout(() => {
+                timer = null;
+            }, wait);
+        }
+    };
+}
 const main = async () => {
-    //console.log("Starting…")
     const RichTexts = Array.from(document.querySelectorAll(".RichText"));
     for (let RichText of RichTexts) {
         try {
             let result;
-            //console.log(RichText)
-            if (RichText.parentElement.classList.contains("Editable"))
+            if (RichText.parentElement && RichText.parentElement.classList.contains("Editable"))
                 continue;
             if (window.location.hostname.includes('zhuanlan')) {
-                if (RichText.closest('.Post-Main').querySelector(".zhihubackup-container"))
+                if (RichText.closest('.Post-Main')?.querySelector(".zhcollect-minimal-btns, .zhihubackup-container"))
                     continue;
             }
             else {
                 if (RichText.closest('.PinItem')) {
                     if (!RichText.closest('.RichContent-inner'))
-                        continue; //每个带图想法有3个RichText，除掉图、假转发
-                    //if (RichText.children[0].classList.contains("Image-Wrapper-Preview")) continue
+                        continue;
                     if (RichText.closest('.PinItem-content-originpin'))
-                        continue; //被转发想法
+                        continue;
                 }
-                if (RichText.closest('.RichContent').querySelector(".zhihubackup-container"))
+                if (RichText.closest('.RichContent')?.querySelector(".zhcollect-minimal-btns, .zhihubackup-container"))
                     continue;
                 const richInner = RichText.closest('.RichContent-inner');
                 if (richInner && richInner.querySelector(".ContentItem-more"))
-                    continue; //未展开
-                if (RichText.closest('.RichContent').querySelector(".ContentItem-expandButton"))
                     continue;
-                //if (RichText.textContent.length == 0) continue
+                if (RichText.closest('.RichContent')?.querySelector(".ContentItem-expandButton"))
+                    continue;
             }
             const aButtonContainer = ButtonContainer.cloneNode(true);
-            //父级
             let parent_dom = RichText.closest('.List-item') ||
                 RichText.closest('.Post-content') ||
                 RichText.closest('.PinItem') ||
                 RichText.closest('.CollectionDetailPageItem') ||
-                RichText.closest('.Card');
-            if (parent_dom.querySelector('.Catalog')) {
-                aButtonContainer.firstElementChild.style.position = 'fixed';
-                aButtonContainer.firstElementChild.style.top = 'unset';
-                aButtonContainer.firstElementChild.style.bottom = '60px';
-            }
-            let p = RichText.closest('.RichContent') || RichText.closest('.Post-RichTextContainer');
-            p.prepend(aButtonContainer);
-            // 为 textarea 添加事件监听器，阻止事件冒泡，确保可以正常输入
-            const textareaRemark = parent_dom.querySelector(".to-remark");
-            textareaRemark.addEventListener("click", (e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                textareaRemark.focus();
-            }, true); // 使用捕获阶段
-            const ButtonMarkdown = parent_dom.querySelector(".to-copy");
-            ButtonMarkdown.addEventListener("click", throttle(async (event) => {
-                try {
-                    const res = await (0,dealItem/* default */.Z)(RichText, 'copy', event);
-                    if (!res)
-                        return; // 取消保存
-                    result = {
-                        textString: res.textString,
-                        title: res.title,
-                    };
-                    /*console.log(result.markdown.join("\n\n"))*/
-                    navigator.clipboard.writeText(result.textString);
-                    ButtonMarkdown.innerHTML = "复制成功✅";
-                    setTimeout(() => {
-                        ButtonMarkdown.innerHTML = "复制为Markdown";
-                    }, 3000);
+                RichText.closest('.Card') || RichText;
+            if (getUIMode() === 'full') {
+                if (getSidebarTriggerMode() === 'chevron') {
+                    aButtonContainer.classList.add('zhihubackup-chevron-mode');
                 }
-                catch (e) {
-                    console.log(e);
-                    ButtonMarkdown.innerHTML = "发生错误❌<br>请打开控制台查看";
-                    setTimeout(() => {
-                        ButtonMarkdown.innerHTML = "复制为Markdown";
-                    }, 3000);
+                const containerEl = aButtonContainer.querySelector('.zhihubackup-container');
+                if (parent_dom.querySelector && parent_dom.querySelector('.Catalog') && containerEl) {
+                    containerEl.style.position = 'fixed';
+                    containerEl.style.top = 'unset';
+                    containerEl.style.bottom = '60px';
                 }
-            }));
-            const ButtonZip = parent_dom.querySelector(".to-zip");
-            ButtonZip.addEventListener("click", throttle(async (event) => {
-                try {
-                    ButtonZip.innerHTML = "下载中……";
-                    const res = await (0,dealItem/* default */.Z)(RichText, 'zip', event);
-                    if (!res)
-                        return ButtonZip.innerHTML = "下载为 ZIP"; // 取消保存
-                    result = {
-                        zip: res.zip,
-                        title: res.title,
-                    };
-                    const blob = await result.zip.generateAsync({ type: "blob" });
-                    (0,FileSaver_min.saveAs)(blob, result.title + ".zip");
-                    ButtonZip.innerHTML = "下载成功✅<br>请看下载记录";
-                    setTimeout(() => {
-                        ButtonZip.innerHTML = "下载为 ZIP";
-                    }, 5000);
-                }
-                catch (e) {
-                    console.log(e);
-                    ButtonZip.innerHTML = "发生错误❌<br>请打开控制台查看";
-                    setTimeout(() => {
-                        ButtonZip.innerHTML = "下载为 ZIP";
-                    }, 5000);
-                }
-            }));
-            const ButtonPNG = parent_dom.querySelector(".to-png");
-            ButtonPNG.addEventListener("click", throttle(async (event) => {
-                try {
-                    const res = await (0,dealItem/* default */.Z)(RichText, 'png', event);
-                    if (!res)
-                        return; // 取消保存
-                    result = {
-                        title: res.title,
-                    };
-                    let clip = parent_dom;
-                    clip.classList.add("to-screenshot");
-                    let saveCM = (0,utils/* getCommentSwitch */.vE)(RichText);
-                    !saveCM ? clip.classList.add("no-cm") : 0;
-                    let svgDefs = document.querySelector("#MathJax_SVG_glyphs");
-                    svgDefs ? svgDefs.style.visibility = "visible" : 0;
-                    Qt(clip, {
-                        backgroundColor: "#fff",
-                        filter(el) {
-                            if (el.tagName == 'DIV' && el.classList.contains('zhihubackup-wrap'))
-                                return false;
-                            else
-                                return true;
-                        },
-                    }).then((dataUrl) => {
-                        const link = document.createElement('a');
-                        link.download = result.title + ".png";
-                        link.href = dataUrl;
-                        link.click();
-                        setTimeout(() => {
-                            clip.classList.remove("to-screenshot");
-                            !saveCM ? clip.classList.remove("no-cm") : 0;
-                            //svgDefs2.remove()
-                            ButtonPNG.innerHTML = "剪藏为 PNG";
-                        }, 5000);
+                let p = RichText.closest('.RichContent') || RichText.closest('.Post-RichTextContainer') || RichText;
+                p.prepend(aButtonContainer);
+                const closeAllSidebars = (except) => {
+                    document.querySelectorAll('.zhihubackup-wrap.is-open').forEach((el) => {
+                        if (el !== except)
+                            el.classList.remove('is-open');
                     });
-                    ButtonPNG.innerHTML = "请稍待片刻✅<br>查看下载记录";
+                };
+                // Chevron trigger: hover or click to open sidebar, single active panel globally
+                const trigger = aButtonContainer.querySelector('.zhihubackup-trigger');
+                if (trigger) {
+                    trigger.addEventListener('mouseenter', () => {
+                        closeAllSidebars(aButtonContainer);
+                        aButtonContainer.classList.add('is-open');
+                    });
+                    trigger.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        const wasOpen = aButtonContainer.classList.contains('is-open');
+                        closeAllSidebars();
+                        if (!wasOpen) {
+                            aButtonContainer.classList.add('is-open');
+                        }
+                    });
+                    aButtonContainer.addEventListener('mouseleave', () => {
+                        aButtonContainer.classList.remove('is-open');
+                    });
                 }
-                catch (e) {
-                    console.log(e);
-                    ButtonPNG.innerHTML = "发生错误❌<br>请打开控制台查看";
-                    setTimeout(() => {
-                        ButtonPNG.innerHTML = "剪藏为 PNG";
-                    }, 5000);
-                }
-            }));
-            const ButtonText = parent_dom.querySelector(".to-text");
-            ButtonText.addEventListener("click", throttle(async (event) => {
-                try {
-                    const res = await (0,dealItem/* default */.Z)(RichText, 'text', event);
-                    if (!res)
-                        return; // 取消保存
-                    result = {
-                        textString: res.textString,
-                        title: res.title,
-                    };
-                    const blob = new Blob([result.textString], { type: 'text/plain' });
-                    (0,FileSaver_min.saveAs)(blob, result.title + ".md");
-                    ButtonText.innerHTML = "下载成功✅<br>请看下载记录，以文本方式打开";
-                    setTimeout(() => {
-                        ButtonText.innerHTML = "下载为纯文本";
-                    }, 5000);
-                }
-                catch (e) {
-                    console.log(e);
-                    ButtonText.innerHTML = "发生错误❌<br>请打开控制台查看";
-                    setTimeout(() => {
-                        ButtonText.innerHTML = "下载为纯文本";
-                    }, 5000);
-                }
-            }));
-            const ButtonObsidian = parent_dom.querySelector(".to-obsidian");
-            ButtonObsidian.addEventListener("click", throttle(async (event) => {
-                try {
-                    let saveType = await (0,obsidianSaver/* selectObsidianVault */.EE)();
-                    if (!saveType)
-                        return; // 取消保存
-                    if (saveType == 'text') {
-                        const res = await (0,dealItem/* default */.Z)(RichText, 'text');
-                        if (!res)
-                            return; // 取消保存
-                        result = {
-                            textString: res.textString,
-                            title: res.title,
-                        };
-                        await (0,obsidianSaver/* saveFile */.yH)(result, saveType);
+            }
+            else {
+                RichText.prepend(aButtonContainer);
+            }
+            const textareaRemark = parent_dom.querySelector(".to-remark");
+            if (textareaRemark) {
+                textareaRemark.addEventListener("click", (e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    textareaRemark.focus();
+                }, true);
+            }
+            const bindCopyBtn = (selector, mode, defaultText) => {
+                const btn = parent_dom.querySelector(selector);
+                if (!btn)
+                    return;
+                btn.addEventListener("click", throttle(async (event) => {
+                    try {
+                        const res = await (0,dealItem/* default */.A)(RichText, mode, event);
+                        if (!res || !res.textString) {
+                            btn.innerHTML = "发生错误❌";
+                            setTimeout(() => { btn.innerHTML = defaultText; }, 2000);
+                            return;
+                        }
+                        copyToClipboard(res.textString);
+                        btn.innerHTML = "复制成功✅";
+                        setTimeout(() => { btn.innerHTML = defaultText; }, 1500);
                     }
-                    else if (saveType.slice(0, 3) == 'zip') {
-                        const res = await (0,dealItem/* default */.Z)(RichText, 'zip');
-                        if (!res)
-                            return; // 取消保存
-                        result = {
-                            zip: res.zip,
-                            title: res.title,
-                        };
-                        await (0,obsidianSaver/* saveFile */.yH)(result, saveType);
+                    catch (e) {
+                        console.error(e);
+                        btn.innerHTML = "发生错误❌";
+                        setTimeout(() => { btn.innerHTML = defaultText; }, 2000);
                     }
-                    else if (saveType == 'png') {
-                        const res = await (0,dealItem/* default */.Z)(RichText, 'png');
-                        if (!res)
-                            return; // 取消保存
-                        let clip = parent_dom;
-                        clip.classList.add("to-screenshot");
-                        let saveCM = (0,utils/* getCommentSwitch */.vE)(RichText);
-                        !saveCM ? clip.classList.add("no-cm") : 0;
-                        let svgDefs = document.querySelector("#MathJax_SVG_glyphs");
-                        svgDefs ? svgDefs.style.visibility = "visible" : 0;
-                        Qt(clip, {
-                            backgroundColor: "#fff",
-                            filter(el) {
-                                if (el.tagName == 'DIV' && el.classList.contains('zhihubackup-wrap'))
-                                    return false;
-                                else
-                                    return true;
-                            },
-                        }).then(async (dataUrl) => {
+                }));
+            };
+            bindCopyBtn(".to-copy-context", "copy_context", "复制标题+正文");
+            bindCopyBtn(".to-copy-content", "copy_content", "复制正文");
+            bindCopyBtn(".to-copy", "copy_content", "复制为Markdown");
+            const bindSaveBtn = (selector, saveType) => {
+                const btn = parent_dom.querySelector(selector);
+                if (!btn)
+                    return;
+                btn.addEventListener("click", throttle(async (event) => {
+                    try {
+                        let result;
+                        if (saveType.slice(0, 4) == 'text') {
+                            const res = await (0,dealItem/* default */.A)(RichText, 'text');
+                            if (!res)
+                                return;
                             result = {
-                                textString: dataUrl,
+                                textString: res.textString,
                                 title: res.title,
                             };
-                            clip.classList.remove("to-screenshot");
-                            !saveCM ? clip.classList.remove("no-cm") : 0;
-                            await (0,obsidianSaver/* saveFile */.yH)(result, saveType);
+                            await (0,obsidianSaver/* saveFile */.OJ)(result, saveType);
+                        }
+                        else if (saveType.slice(0, 3) == 'zip') {
+                            const res = await (0,dealItem/* default */.A)(RichText, 'zip');
+                            if (!res)
+                                return;
+                            result = {
+                                zip: res.zip,
+                                title: res.title,
+                            };
+                            await (0,obsidianSaver/* saveFile */.OJ)(result, saveType);
+                        }
+                        else if (saveType == 'png') {
+                            const res = await (0,dealItem/* default */.A)(RichText, 'png');
+                            if (!res)
+                                return;
+                            let clip = parent_dom;
+                            clip.classList.add("to-screenshot");
+                            let saveCM = (0,utils/* getCommentSwitch */.mK)(RichText);
+                            !saveCM ? clip.classList.add("no-cm") : 0;
+                            let svgDefs = document.querySelector("#MathJax_SVG_glyphs");
+                            svgDefs ? svgDefs.style.visibility = "visible" : 0;
+                            domToPng(clip, {
+                                backgroundColor: "#fff",
+                                filter(el) {
+                                    if (el.tagName == 'DIV' && el.classList.contains('zhihubackup-wrap'))
+                                        return false;
+                                    else
+                                        return true;
+                                },
+                            }).then(async (dataUrl) => {
+                                result = {
+                                    textString: dataUrl,
+                                    title: res.title,
+                                };
+                                clip.classList.remove("to-screenshot");
+                                !saveCM ? clip.classList.remove("no-cm") : 0;
+                                await (0,obsidianSaver/* saveFile */.OJ)(result, saveType);
+                            });
+                        }
+                    }
+                    catch (e) {
+                        console.log(e);
+                        alert('发生错误❌请打开控制台查看\n你可以关闭窗口后再试一次！');
+                    }
+                }));
+            };
+            bindSaveBtn(".to-zip", "zip");
+            bindSaveBtn(".to-text", "text");
+            bindSaveBtn(".to-png", "png");
+            const ButtonObsidian = parent_dom.querySelector(".to-obsidian");
+            if (ButtonObsidian) {
+                ButtonObsidian.addEventListener("click", throttle(async (event) => {
+                    try {
+                        (0,obsidianSaver/* selectObsidianVault */.yY)(async (vault, folder) => {
+                            const res = await (0,dealItem/* default */.A)(RichText, 'obsidian', event);
+                            if (!res)
+                                return;
+                            if (res.zip) {
+                                (0,obsidianSaver/* saveFile */.OJ)(res.zip, vault, folder, res.title);
+                            }
+                            else if (res.textString) {
+                                const zip = new jszip_min();
+                                zip.file("index.md", res.textString);
+                                (0,obsidianSaver/* saveFile */.OJ)(zip, vault, folder, res.title);
+                            }
+                            (0,toast/* showToast */.P)('✅ 导出成功！');
                         });
                     }
-                }
-                catch (e) {
-                    console.log(e);
-                    alert('发生错误❌请打开控制台查看\n你可以关闭窗口后再试一次！');
-                }
-            }));
+                    catch (e) {
+                        console.error(e);
+                        (0,toast/* showToast */.P)('❌ 导出失败！');
+                    }
+                }));
+            }
         }
         catch (e) {
-            console.log(e);
+            console.error(e);
         }
     }
 };
-function throttle(fn, delay = 2000) {
-    let flag = true;
-    return function (...args) {
-        if (flag) {
-            flag = false;
-            setTimeout(() => {
-                flag = true;
-            }, delay);
-            return fn.apply(this, args); // 通过 apply 传递参数和 this
-        }
-    };
-}
+mountParseComments();
 setTimeout(() => {
-    let node = document.createElement("style"); //!important
+    let node = document.createElement("style");
     node.appendChild(document.createTextNode(`
+    /* ========== Minimal Mode: Joined Capsule Buttons ========== */
+    .zhcollect-minimal-btns {
+        user-select: none;
+    }
+    .zhcollect-btn {
+        width: 120px;
+        height: 2em;
+        background-color: rgba(85, 85, 85, 0.9);
+        color: white;
+        outline: none;
+        cursor: pointer;
+        border: none;
+        border-radius: 1em;
+        margin: 0 .2em 1em .2em;
+        font-size: .8em;
+        z-index: 999;
+    }
+    .zhcollect-btn:hover {
+        background-color: rgba(60, 60, 60, 0.95);
+    }
+
+    /* ========== Full Mode: Sidebar Layout Architecture ========== */
     .RichContent {
         position: relative;
     }
     .zhihubackup-wrap {
-        opacity: 0;
-        pointer-events: none;
-        transition: opacity 0.5s;
         position: absolute;
-        left: -10em;
+        left: -9.5em;
         top: -100px;
         height: 100%;
         min-height: 200px;
         user-select: none;
-        width: 12em;
+        width: 9.5em; /* 保证整体靠左侧外边距展开，绝不占用正文侧向空间 */
     }
-    .RichContent:hover .zhihubackup-wrap,
-    .ContentItem:hover .zhihubackup-wrap,
-    .Post-content:hover .zhihubackup-wrap,
-    .Post-RichTextContainer:hover .zhihubackup-wrap,
-    .zhihubackup-wrap:hover {
-        opacity: 1;
-        pointer-events: initial;
+
+    /* CRITICAL FIX: Allow Card containers to show overflowing sidebars without clipping or overlapping text! */
+    .Card:has(.zhihubackup-wrap) {
+        overflow: visible !important;
     }
-    .zhihubackup-container {
+
+    /* Default: Native Hover Mode */
+    .zhihubackup-wrap:not(.zhihubackup-chevron-mode) {
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+    }
+    .RichContent:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .ContentItem:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .AnswerItem:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .ArticleItem:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .PinItem:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .Post-content:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .Post-RichTextContainer:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .List-item:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .Card:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .zhihubackup-wrap:not(.zhihubackup-chevron-mode):hover {
+        opacity: 1 !important;
+        pointer-events: initial !important;
+    }
+    .zhihubackup-wrap:not(.zhihubackup-chevron-mode) .zhihubackup-container {
         position: sticky;
         top: 120px;
-        /*display: flex;
-        flex-direction: column;
-        justify-content: space-around;
-        height: 22em;*/
         width: min-content;
         max-width: 8em;
         z-index: 2;
     }
+
+    /* Chevron Mode Sticky Box */
+    .zhihubackup-chevron-mode .zhihubackup-sticky-box {
+        position: sticky;
+        top: 200px; /* 悬浮吸顶高度（低于知乎顶部导航栏） */
+        display: flex;
+        flex-direction: row; /* 正向 Row：左侧为功能菜单，右侧紧贴正文的是 Chevron 按钮 */
+        align-items: flex-start;
+        justify-content: flex-end; /* 靠右对齐：触发按钮紧贴回答正文左边界 */
+        gap: 8px;
+        width: 100%;
+    }
+    .zhihubackup-chevron-mode .zhihubackup-trigger {
+        position: relative;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: rgba(60, 60, 60, 0.7);
+        background: rgba(255, 255, 255, 0.85);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        border: 1px solid rgba(0, 0, 0, 0.08);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        transition: opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+                    background 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+                    transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+                    box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+                    color 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+        opacity: 0.35; /* 默认低透明度常驻浮现，能看清按钮位置但绝不刺眼 */
+        z-index: 3;
+        pointer-events: auto;
+        box-sizing: border-box;
+        width: 24px;
+        height: 38px;
+        border-radius: 12px;
+        flex-shrink: 0;
+        margin-right: 12px; /* ★ 向左平移12px骑在中线上（一半在卡片内，一半在卡片外） */
+    }
+    .zhihubackup-chevron-mode .zhihubackup-trigger::before {
+        content: '';
+        position: absolute;
+        top: -16px;
+        bottom: -16px;
+        left: -16px;
+        right: -16px;
+        border-radius: inherit;
+    }
+    .zhihubackup-chevron-mode .zhihubackup-trigger svg {
+        transition: transform 0.3s ease;
+    }
+    .zhihubackup-wrap.is-open .zhihubackup-trigger {
+        opacity: 0.85;
+    }
+
+    .zhihubackup-trigger:hover {
+        opacity: 1 !important;
+        background: rgba(255, 255, 255, 0.98);
+        border-color: rgba(23, 114, 246, 0.3);
+        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.14), 0 2px 6px rgba(0, 0, 0, 0.05);
+        transform: scale(1.18);
+        color: #1772f6;
+    }
+
+    .zhihubackup-chevron-mode .zhihubackup-container {
+        position: static;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+    }
+
+    .zhihubackup-wrap.is-open .zhihubackup-container {
+        opacity: 1;
+        pointer-events: auto;
+    }
+    .zhihubackup-wrap.is-open .zhihubackup-trigger svg {
+        transform: rotate(180deg);
+    }
+
     .zhihubackup-container .Button {
         width: 8em;
         margin-bottom: 8px;
@@ -4958,7 +5612,6 @@ setTimeout(() => {
     }
     .zhihubackup-container input,
     .zhihubackup-container textarea {
-        /*border: 1px solid #777;*/
         background-color: #0000;
         font-size: 14px;
         color: #1772f6;
@@ -4983,7 +5636,7 @@ setTimeout(() => {
         margin: 0 -20px -10px!important;
     }
     .to-screenshot.Post-content .RichContent-actions {
-        position: initial!important;/*专栏*/
+        position: initial!important;
         box-shadow: unset!important;
     }
     .to-screenshot.Post-content {
@@ -4997,12 +5650,12 @@ setTimeout(() => {
         align-items: center;
     }
     .to-screenshot.PinItem .RichText>.RichText:has(a[data-first-child]) {
-        display: flex;/*想法-卡片链接*/
+        display: flex;
         flex-direction: column;
         align-items: center;
     }
     .to-screenshot .ContentItem-actions>.ContentItem-actions {
-        margin-top: -10px!important;/*想法*/
+        margin-top: -10px!important;
     }
     .to-screenshot .css-m4psdq{
         opacity: 0;
@@ -5033,7 +5686,7 @@ setTimeout(() => {
         margin: 0 !important;
     }
     .to-screenshot.PinItem{
-        margin: 16px 0;/*想法增加留白*/
+        margin: 16px 0;
         padding: 0 16px;
         width: 690px;
     }
@@ -5041,13 +5694,10 @@ setTimeout(() => {
         max-width: 706px!important;
     }
     .to-screenshot .Recommendations-Main{
-        display: none;/*文章推荐阅读*/
+        display: none;
     }
     .to-screenshot .css-kt4t4n{
-        display: none;/*下方黏性评论栏*/
-    }
-    .to-screenshot .zhihubackup-container{
-        /*display: none;*/
+        display: none;
     }
     .RichContent:has(.ContentItem-more) .zhihubackup-wrap,
     .Post-RichTextContainer:has(.ContentItem-more) .zhihubackup-wrap{
@@ -5063,12 +5713,10 @@ setTimeout(() => {
         opacity: 1;
         pointer-events: initial;
     }
-    .Card:has(.zhihubackup-wrap){
-        overflow: visible!important;
-    }
     `));
     let head = document.querySelector("head");
-    head.appendChild(node);
+    if (head)
+        head.appendChild(node);
     if (window.innerWidth < 1275) {
         let node2 = document.createElement("style");
         node2.appendChild(document.createTextNode(`
@@ -5085,31 +5733,29 @@ setTimeout(() => {
             z-index: 2;
         }
         `));
-        head.appendChild(node2);
+        if (head)
+            head.appendChild(node2);
     }
 }, 30);
 setTimeout(() => {
     main();
-    mountParseComments();
     // @ts-ignore
     window.zhbf = main;
-    // 在window对象上创建存储空间
     // @ts-ignore
     window.ArticleComments = window.ArticleComments || {};
     document.querySelector('.Topstory-tabs')?.addEventListener('click', () => {
         setTimeout(registerBtn, 100);
     });
 }, 300);
-let timer = null;
+let scrollTimer = null;
 window.addEventListener("scroll", () => {
-    //debounce
-    if (timer) {
-        clearTimeout(timer);
+    if (scrollTimer) {
+        clearTimeout(scrollTimer);
     }
-    timer = setTimeout(main, 1000);
+    scrollTimer = setTimeout(main, 1000);
 });
 
-;// CONCATENATED MODULE: ./src/entry.ts
+;// ./src/entry.ts
 
 
 })();

--- a/scripts/build-tampermonkey.js
+++ b/scripts/build-tampermonkey.js
@@ -36,8 +36,4 @@ fs.writeFileSync("./dist/tampermonkey-script.js", `// ==UserScript==
 ${TampermonkeyConfig}
 // ==/UserScript==
 
-/** 
-${readme.match(/## Changelog.*$/s)[0].slice(0,450).trim() + '...\n...\n'}
- */
-
 ${UserScriptContent}`, "utf-8")

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,295 +1,152 @@
 import type { AuthorType } from "./types"
 
-/**
- * Converts a Zhihu link to a normal link.
- * @param link - The Zhihu link to convert.
- * @returns The converted normal link.
- */
 export const ZhihuLink2NormalLink = (link: string): string => {
-    const url = new URL(link)
-    if (url.hostname == "link.zhihu.com") {
-        const target = new URLSearchParams(url.search).get("target")
-        return decodeURIComponent(target)
-    }
-    else {
-        if (link.match(/#/)) return '#' + link.split('#')[1]
-        else return link
+    try {
+        const url = new URL(link)
+        if (url.hostname == "link.zhihu.com") {
+            const target = new URLSearchParams(url.search).get("target")
+            return decodeURIComponent(target || "")
+        } else {
+            if (link.match(/#/)) return '#' + link.split('#')[1]
+            else return link
+        }
+    } catch (e) {
+        return link
     }
 }
 
-
-/**
- * Get the title of the dom.
- * @param dom - The dom to get title.
- * @returns The title of the dom.
- */
-export const getTitle = (dom: HTMLElement, scene: string, type: string) => {
-    let t
-    if (scene == "follow" || scene == "people" || scene == "collection" || scene == "pin") {
-        let title_dom = dom.closest('.ContentItem').querySelector("h2.ContentItem-title a")
-        if (type == "answer" || type == "article") {
-            //搜索结果页最新讨论
-            !title_dom ? title_dom = dom.closest('.HotLanding-contentItem').querySelector("h2.ContentItem-title a") : 0
-            t = title_dom.textContent
-
-        }
-        else {//想法
-            if (title_dom) {
-                t = "想法：" + title_dom.textContent + '-' + dom.innerText.slice(0, 16).trim().replace(/\s/g, "")
-            } else t = "想法：" + dom.innerText.slice(0, 24).trim().replace(/\s/g, "")
-        }
-    }
-    //问题/回答
-    else if (scene == "question" || scene == "answer") {
-        t = (dom.closest('.QuestionPage').querySelector("meta[itemprop=name]") as HTMLMetaElement).content
-    }
-    //文章
-    else if (scene == "article") {
-        t = dom.closest('.Post-Main').querySelector("h1.Post-Title").textContent
-    }
-    else t = "无标题"
-    //替换英文问号为中文问号，因标题中间也可能有问号所以不去掉
-    return t.replace(/\?/g, "？").replace(/\/|\\|<|>|"|\*|\?|\||\:/g, "-")
-}
-
-/**
- * Get the author of the dom.
- * @param dom - The dom to get author.
- * @returns The author of the dom.
- */
-export const getAuthor = (dom: HTMLElement, scene: string, type: string): AuthorType => {
-    let author_dom
-    //寻找包含昵称+链接+签名的节点
-
-    if (scene == "follow") {
-        let p = dom.closest('.ContentItem')
-        //唯独关注页作者在ContentItem外面，原创内容没有作者栏
-        author_dom = p.querySelector(".AuthorInfo-content") ||
-            dom.closest('.Feed').querySelector(".FeedSource .AuthorInfo-content") ||
-            dom.closest('.Feed').querySelector(".FeedSource-firstline")
-    }
-    ///个人/问题/回答/想法/收藏夹
-    else if (scene == "people" || scene == "question" || scene == "answer" || scene == "pin" || scene == "collection") {
-        let p = dom.closest('.ContentItem')
-        author_dom = p.querySelector(".AuthorInfo-content")
-        // 个人页的搜索结果的想法没有作者栏
-        if (!author_dom && location.href.includes('search')) {
-            author_dom = document.querySelector('.ProfileHeader-title')
-            return {
-                name: author_dom.children[0].textContent,
-                url: location.href.match(/(https.*)\/search/)[1],
-                badge: author_dom.children[1].textContent
+export const getTitle = (dom: HTMLElement, scene?: string, type?: string): string => {
+    try {
+        // 1. Check Question Page (Answer pages like /question/123/answer/456)
+        const qPage = dom.closest('.QuestionPage') || document.querySelector('.QuestionPage');
+        if (qPage) {
+            const metaName = qPage.querySelector('meta[itemprop=name]') as HTMLMetaElement;
+            if (metaName && metaName.content) {
+                return metaName.content.trim().replace(/\?/g, "？").replace(/\/|\\|<|>|"|\*|\||\:/g, "-");
+            }
+            const qTitle = qPage.querySelector('.QuestionHeader-title, h1.QuestionHeader-title') as HTMLElement;
+            if (qTitle && qTitle.innerText) {
+                return qTitle.innerText.trim().replace(/\?/g, "？").replace(/\/|\\|<|>|"|\*|\||\:/g, "-");
             }
         }
-    }
-    //文章
-    else if (scene == "article") {
-        author_dom = dom.closest('.Post-Main').querySelector(".Post-Author")
-    }
 
-    if (author_dom) {
-        let authorName_dom = author_dom.querySelector(".AuthorInfo-name .UserLink-link") as HTMLAnchorElement ||
-            author_dom.querySelector(".UserLink-link") as HTMLAnchorElement ||
-            author_dom.querySelector(".UserLink.AuthorInfo-name")//匿名用户
-        let authorBadge_dom = author_dom.querySelector(".AuthorInfo-badge") as HTMLDivElement
-        //console.log("authorName_dom", authorName_dom)
-        return {
-            name: authorName_dom.innerText || (authorName_dom.children[0] ? authorName_dom.children[0].getAttribute("alt") : ''),//???//没有名字的用户https://www.zhihu.com/people/8-90-74/answers
-            url: authorName_dom.href,
-            badge: authorBadge_dom ? authorBadge_dom.innerText : ""
-        }
-    }
-    else console.error("未找到author_dom")
-}
-
-/**
- * Get the URL of the dom.
- * 应该按每个内容获取URL，而非目前网址
- * @param dom - The dom to get URL.
- * @returns The URL of the dom.
- */
-export const getURL = (dom: HTMLElement, scene: string, type: string): string => {
-    let url
-    //文章/想法/回答
-    if (scene == "article" || scene == "pin" || scene == "answer") {
-        url = window.location.href
-        let q = url.match(/\?/) ? url.match(/\?/).index : 0
-        if (q) url = url.slice(0, q)
-        return url
-    }
-    //关注/个人/问题/等
-    // if (scene == "follow" || scene == "people" || scene == "question")
-    else {
-        if (type == "answer" || type == "article") {
-            //普通
-            let p = dom.closest('.ContentItem')
-            let url_dom = (p.querySelector(".ContentItem>meta[itemprop=url]") as any)
-            //搜索结果页
-            if (!url_dom) {
-                url_dom = p.querySelector(".ContentItem h2 a")
+        // 2. Check Answer/Article Item in Feed/Lists/Collections
+        const item = dom.closest('.AnswerItem') || dom.closest('.ArticleItem') || dom.closest('.ContentItem') || dom.closest('.Card');
+        if (item) {
+            const titleEl = item.querySelector('h2.ContentItem-title a, .ContentItem-title a, h2.ContentItem-title') as HTMLElement;
+            if (titleEl && titleEl.innerText) {
+                return titleEl.innerText.trim().replace(/\?/g, "？").replace(/\/|\\|<|>|"|\*|\||\:/g, "-");
             }
-            //搜索结果页最新讨论
-            if (!url_dom) {
-                p = dom.closest('.HotLanding-contentItem')
-                url_dom = p.querySelector(".ContentItem h2 a")
+        }
+
+        // 3. Check Zhuanlan Post/Article
+        const postMain = dom.closest('.Post-Main') || document.querySelector('.Post-Main');
+        if (postMain) {
+            const postTitle = postMain.querySelector('h1.Post-Title') as HTMLElement;
+            if (postTitle && postTitle.innerText) {
+                return postTitle.innerText.trim().replace(/\?/g, "？").replace(/\/|\\|<|>|"|\*|\||\:/g, "-");
             }
-            url = url_dom.content || (url_dom.href)
-            if (url.slice(0, 5) != "https") url = "https:" + url
-            return url
         }
-        //pin
-        else {
-            let zopdata = dom.closest('.ContentItem').getAttribute("data-zop")
-            return "https://www.zhihu.com/pin/" + JSON.parse(zopdata).itemId
+
+        // 4. Global Meta & H1 Fallback
+        const globalMeta = document.querySelector('meta[itemprop=name]') as HTMLMetaElement;
+        if (globalMeta && globalMeta.content) {
+            return globalMeta.content.trim().replace(/\?/g, "？").replace(/\/|\\|<|>|"|\*|\||\:/g, "-");
         }
-    }
+
+        const globalH1 = document.querySelector('h1.QuestionHeader-title, h1.Post-Title') as HTMLElement;
+        if (globalH1 && globalH1.innerText) {
+            return globalH1.innerText.trim().replace(/\?/g, "？").replace(/\/|\\|<|>|"|\*|\||\:/g, "-");
+        }
+    } catch (e) {}
+    return "无标题";
 }
 
-/**
- * 
- * 时间：
- * 使用内容下显示的时间
- * 
- */
-export const getTime = async (dom: HTMLElement, scene: string, type?: string): Promise<{
-    created: string,
-    modified: string
-}> => {
-    //关注/个人/问题/回答页
-    //if (scene == "follow" || scene == "people" || scene == "question" || scene == "answer") {//收藏夹
-    //  if (type != "" || type == "article") {
-    let created, modified, time_dom
-    if (scene != "article") {
-        time_dom = dom.closest('.ContentItem').querySelector(".ContentItem-time")
-        created = time_dom.querySelector("a").getAttribute("data-tooltip").slice(4)//2023-12-30 16:12
-        modified = time_dom.querySelector("a").innerText.slice(4)
-        return { created, modified }
-    }
-    else {//文章
-        time_dom = dom.closest('.Post-content').querySelector(".ContentItem-time") as HTMLElement
-        modified = time_dom.childNodes[0].textContent.slice(4)
-        time_dom.click()
-        await new Promise<void>((resolve) => {
-            setTimeout(() => {
-                resolve()
-            }, 1000)
-        })
-        created = time_dom.childNodes[0].textContent.slice(4)
-        time_dom.click()
-        return { created, modified }
-    }
-    //  }
-    //}
+export const getAuthor = (dom: HTMLElement, scene?: string, type?: string): AuthorType => {
+    try {
+        let item = dom.closest('.ContentItem') || dom.closest('.Post-Main') || dom.closest('.PinItem') || dom;
+        if (item) {
+            let authorName_dom = item.querySelector(".AuthorInfo-name .UserLink-link, .UserLink-link, .AuthorInfo-name") as HTMLElement;
+            let authorBadge_dom = item.querySelector(".AuthorInfo-badge, .AuthorInfo-badgeText") as HTMLElement;
+            if (authorName_dom) {
+                let href = (authorName_dom as HTMLAnchorElement).href || "";
+                let name = authorName_dom.innerText || (authorName_dom.children[0] ? authorName_dom.children[0].getAttribute("alt") || "" : "");
+                return {
+                    name: name.trim() || "匿名用户",
+                    url: href,
+                    badge: authorBadge_dom ? authorBadge_dom.innerText.trim() : ""
+                };
+            }
+        }
+    } catch (e) {}
+    return { name: "匿名用户", url: "", badge: "" };
 }
 
-export const getUpvote = (dom: HTMLElement, scene: string | null, type: string): number => {
-    //关注/个人/问题/回答页
-    //if (scene == "follow" || scene == "people" || scene == "question" || scene == "answer") {//收藏夹
-    //up_dom = (getParent(dom, "ContentItem") as HTMLElement).querySelector(".VoteButton--up") as HTMLElement//\n赞同 5.6 万
-    let upvote, up_dom
-    if (type == "pin") {
-        //个人页的想法有2层ContentItem-actions，想法页有1层
-        up_dom = dom.closest('.ContentItem').querySelector(".ContentItem-actions>.ContentItem-actions") ||
-            dom.closest('.ContentItem').querySelector(".ContentItem-actions")
-        up_dom = up_dom.childNodes[0]
-        upvote = up_dom.textContent.replace(/,|\u200B/g, '').slice(3)//0, -4
-        upvote ? 0 : upvote = 0
-    }
-    else if (scene == "article") {
-        up_dom = dom.closest('.Post-content').querySelector(".ContentItem-actions .VoteButton")
-        upvote = up_dom.textContent.replace(/,|\u200B/g, '').slice(3)
-        upvote ? 0 : upvote = 0
-    }
-    else {
-        let zaedata = dom.closest('.ContentItem').getAttribute("data-za-extra-module")
-        //搜索结果页
-        if (window.location.href.includes('/search?')) {
-            upvote = dom.closest('.RichContent').querySelector(".ContentItem-actions .VoteButton").getAttribute('aria-label').slice(3) || 0
+export const getURL = (dom: HTMLElement, scene?: string, type?: string): string => {
+    try {
+        if (window.location.pathname === "/") {
+            let item = dom.closest('.ContentItem') || dom.closest('.AnswerItem') || dom.closest('.ArticleItem');
+            if (item) {
+                let a = item.querySelector("a[data-za-detail-view-id]") as HTMLAnchorElement;
+                if (a && a.href) return a.href;
+            }
         }
-        else upvote = JSON.parse(zaedata).card.content.upvote_num
-    }
-    return parseInt(upvote)
-    //  }
-    //}
+    } catch (e) {}
+    return window.location.origin + window.location.pathname;
 }
 
-export const getCommentNum = (dom: HTMLElement, scene: string, type: string): number => {
-    //关注/个人/问题/回答页
-    //if (scene == "follow" || scene == "people" || scene == "question" || scene == "answer") {//收藏夹
-    let cm, cm_dom, p
-    //被展开的评论区
-    p = dom.closest('.ContentItem')
-    p ? cm_dom = p.querySelector(".css-1k10w8f") : 0
-    if (cm_dom) {
-        cm = cm_dom.textContent.replace(/,|\u200B/g, "").slice(0, -4)
-    }
-    else if (type == "pin") {
-        cm_dom = dom.closest('.ContentItem').querySelector(".ContentItem-actions>.ContentItem-actions") ||
-            dom.closest('.ContentItem').querySelector(".ContentItem-actions")
-        cm_dom = cm_dom.childNodes[1]
-        cm = cm_dom.textContent.replace(/,|\u200B/g, "").slice(0, -4)
-        cm ? 0 : cm = 0
-    }
-    else if (scene == "article") {
-        cm_dom = dom.closest('.Post-content').querySelector(".BottomActions-CommentBtn")
-        cm = cm_dom.textContent.replace(/,|\u200B/g, '').slice(0, -4)
-        cm ? 0 : cm = 0
-    }
-    else {
-        let zaedata = dom.closest('.ContentItem').getAttribute("data-za-extra-module")
-        //搜索结果页
-        if (window.location.href.includes('/search?')) {
-            cm_dom = dom.closest('.RichContent').querySelector("button.ContentItem-action")
-            cm = cm_dom.textContent.replace(/,|\u200B/g, "").slice(0, -4)
+export const getTime = async (dom: HTMLElement, scene?: string) => {
+    try {
+        let item = dom.closest('.ContentItem') || dom.closest('.Post-content') || dom.closest('.PinItem') || dom;
+        let timeEl = item.querySelector('.ContentItem-time, .Post-Time, .PinItem-time, .ContentItem-status');
+        if (timeEl) {
+            let text = (timeEl as HTMLElement).innerText.replace(/\s+/g, ' ').trim();
+            return { created: text, modified: text };
         }
-        else cm = JSON.parse(zaedata).card.content.comment_num
-    }
-    return parseInt(cm)
-    //  }
-    //}
+    } catch (e) {}
+    return { created: "", modified: "" };
+}
+
+export const getUpvote = (dom: HTMLElement, scene?: string, type?: string): string => {
+    try {
+        let item = dom.closest('.ContentItem') || dom.closest('.Post-content') || dom.closest('.PinItem') || dom;
+        let up = item.querySelector('.VoteButton--up, .AnswerItem-extraInfo, button[aria-label*="赞同"]');
+        if (up) return (up as HTMLElement).innerText.replace(/\s+/g, ' ').trim();
+    } catch (e) {}
+    return "";
+}
+
+export const getCommentNum = (dom: HTMLElement, scene?: string, type?: string): string => {
+    try {
+        let item = dom.closest('.ContentItem') || dom.closest('.Post-content') || dom;
+        let btn = item.querySelector('.ContentItem-actions button:has(.Zi--comment)');
+        if (btn) return btn.textContent || "";
+    } catch (e) {}
+    return "";
 }
 
 export const getRemark = (dom: HTMLElement): string => {
-    let remark, p = dom.closest('.ContentItem')//文章页没有，remark = remark.replace(/\/|\\|<|>|"|\*|\?|\||\:/g, "-")
-    if (!p) p = dom.closest('.PinItem')
-    if (!p) p = dom.closest('.Post-content')
-    if (p) remark = (p.querySelector("textarea.to-remark") as HTMLInputElement).value.replace(/\s/g, "-")
-    if (remark.match(/\/|\\|<|>|"|\*|\?|\||\:/g)) return "非法备注"
-    return remark
-}
-
-/**
- * 获取是否需要保存评论，用于截图，zip
- */
-export const getCommentSwitch = (dom: HTMLElement): boolean => {
-    let s, p = dom.closest('.ContentItem')
-    if (!p) p = dom.closest('.PinItem')
-    if (!p) p = dom.closest('.Post-content')
-    if (p) s = (p.querySelector("input.to-cm") as HTMLInputElement).checked
-    return s
-}
-
-/**
- * Get the Location of the dom.
- * @param dom - The dom.
- * @returns string | null
- */
-export const getLocation = (dom: HTMLElement, scene: string, type: string): string | null => {
-    let location, el = dom.closest('.ContentItem')//想法类型、文章页没有
-    if (!el) el = dom.closest('.PinItem')
-    if (!el) el = dom.closest('.Post-content')
     try {
-        if (el) {
-            location = el.querySelector('.ContentItem-time').childNodes[1]?.textContent.slice(6)
+        let wrap = dom.closest('.zhihubackup-wrap') || dom.closest('.zhcollect-minimal-btns');
+        if (wrap) {
+            let ta = wrap.querySelector('.to-remark') as HTMLTextAreaElement;
+            if (ta) return ta.value;
         }
-        if (!location && scene == "people") {
-            let name = document.querySelector('.ProfileHeader-name').childNodes[0].textContent
-            if (name == getAuthor(dom, scene, type).name) {
-                location = document.querySelector('.css-1xfvezd').textContent.slice(5)
-            }
+    } catch (e) {}
+    return "";
+}
+
+export const getCommentSwitch = (dom: HTMLElement): boolean => {
+    try {
+        let wrap = dom.closest('.zhihubackup-wrap');
+        if (wrap) {
+            let cb = wrap.querySelector('.to-cm') as HTMLInputElement;
+            if (cb) return cb.checked;
         }
-    } catch (e) {
-        console.error('保存location出错', e)
-    }
-    return location
+    } catch (e) {}
+    return false;
+}
+
+export const getLocation = (dom: HTMLElement, scene?: string, type?: string): string => {
+    return "";
 }

--- a/src/dealItem.ts
+++ b/src/dealItem.ts
@@ -32,38 +32,52 @@ function detectScene(): string {
     return scene
 }
 
-function detectType(dom: HTMLElement, bt: string, ev?: Event): string | null {
-    //ContentItem
-    let type
-    if (dom.closest('.AnswerItem')) type = "answer"
-    else if (dom.closest('.ArticleItem')) type = "article"
-    else if (dom.closest('.Post-content')) type = "article"
-    else if (dom.closest('.PinItem')) type = "pin"
-    else {
-        console.log("未知内容")
-
-        if (!ev) {
-            alert('请勿收起又展开内容，否则会保存失败。请手动重新保存。')
-        }
-        else {
-            let zhw = (ev.target as HTMLElement).closest('.zhihubackup-wrap'),
-                bz = zhw.querySelector('textarea').value,
-                fa = zhw.closest('.ContentItem') || zhw.closest('.Post-content') || zhw.closest('.HotLanding-contentItem')
-            !fa ? alert('请勿收起又展开内容，否则会保存失败。请重新保存。') : 0
-            setTimeout(() => {
-                fa.querySelector('textarea').value = bz
-            }, 200)
-            setTimeout(() => {
-                (fa.querySelector(`.to-${bt}`) as HTMLElement).click()
-            }, 250)
-        }
-        document.querySelectorAll('.zhihubackup-wrap').forEach((w) => w.remove())
-        // @ts-ignore
-        setTimeout(window.zhbf, 100)
-        return;
-    }
-    return type
+function detectType(dom: HTMLElement, bt: string, ev?: Event): string {
+    if (dom.closest('.AnswerItem')) return "answer";
+    if (dom.closest('.ArticleItem') || dom.closest('.Post-content') || dom.closest('.Post-Main')) return "article";
+    if (dom.closest('.PinItem')) return "pin";
+    if (dom.closest('.ContentItem')) return "answer";
+    return "answer";
 }
+
+
+export const getHeaderMarkdown = (dom: HTMLElement, scene: string, type: string): string => {
+    const title = getTitle(dom, scene, type);
+    const url = getURL(dom, scene, type);
+    const author = getAuthor(dom, scene, type);
+    const upvote = getUpvote(dom, scene, type);
+    
+    let item = dom.closest('.ContentItem') || dom.closest('.Post-content') || dom.closest('.PinItem') || dom;
+    let timeText = "";
+    if (item) {
+        let timeEl = item.querySelector('.ContentItem-time, .Post-Time, .PinItem-time, .ContentItem-status');
+        if (timeEl) timeText = (timeEl as HTMLElement).innerText.replace(/\s+/g, ' ').trim();
+    }
+    
+    let lines: string[] = [];
+    if (title && title !== "无标题") {
+        lines.push(`# ${title}\n`);
+    }
+    if (url && !url.includes("#WARNING")) {
+        lines.push(`> **原文链接**：[${url}](${url})`);
+    }
+    if (author && author.name) {
+        let authorStr = author.url ? `[${author.name}](${author.url})` : author.name;
+        if (author.badge) authorStr += ` (${author.badge})`;
+        lines.push(`> **作者**：${authorStr}`);
+    }
+    if (timeText) {
+        lines.push(`> **时间**：${timeText}`);
+    }
+    if (upvote) {
+        lines.push(`> **赞同数**：${upvote}`);
+    }
+    
+    if (lines.length > 0) {
+        return lines.join("\n") + "\n\n---\n\n";
+    }
+    return "";
+};
 
 export default async (dom: HTMLElement, button?: string, event?: Event): Promise<DealItemResult> => {
     //console.log(dom)
@@ -173,7 +187,7 @@ export default async (dom: HTMLElement, button?: string, event?: Event): Promise
      * 生成目录
      */
     const TOC = ((): string[] | null => {
-        let toc = (dom.closest('.ContentItem') || dom.closest('.Post-content') as HTMLElement).querySelector(".Catalog-content")
+        let toc = (dom.closest('.ContentItem') || dom.closest('.Post-content') as HTMLElement)?.querySelector(".Catalog-content")
         let items: string[] = []
         if (toc) {
             let i = 1, j = 1
@@ -208,8 +222,8 @@ export default async (dom: HTMLElement, button?: string, event?: Event): Promise
     }
 
     //是转发的想法，对源想法解析，并准备附加到新想法下面
-    if (type == "pin" && dom.closest('.PinItem').querySelector(".PinItem-content-originpin")) {
-        const dom2 = dom.closest('.PinItem').querySelector(".PinItem-content-originpin .RichText")
+    if (type == "pin" && dom.closest('.PinItem')?.querySelector(".PinItem-content-originpin")) {
+        const dom2 = dom.closest('.PinItem')?.querySelector(".PinItem-content-originpin .RichText")
         const lex2 = lexer(dom2.childNodes as NodeListOf<Element>, type)
         //markdown = markdown.concat(parser(lex2).map((l) => "> " + l))
         originPinMD.push('\n\n' + parser(lex2).map((l) => "> " + l).join("\n> \n"))
@@ -217,17 +231,17 @@ export default async (dom: HTMLElement, button?: string, event?: Event): Promise
 
     // 获取想法图片/标题
     if (type == "pin") {
-        const pinItem = dom.closest('.PinItem')
-        if (pinItem.querySelector(".ContentItem-title"))
+        const pinItem = dom.closest('.PinItem') as HTMLElement
+        if (pinItem?.querySelector(".ContentItem-title"))
             lex.unshift({
                 type: TokenType.Text,
                 content: [{
                     type: TokenType.PlainText,
-                    text: '**' + pinItem.querySelector(".ContentItem-title").textContent + '**'
+                    text: '**' + (pinItem.querySelector(".ContentItem-title")?.textContent || '') + '**'
                 }]
             })
-        if (pinItem.querySelector(".PinItem-remainContentRichText")) {
-            const imgs = pinItem.querySelectorAll(".PinItem-remainContentRichText img")
+        if (pinItem?.querySelector(".PinItem-remainContentRichText")) {
+            const imgs = pinItem?.querySelectorAll(".PinItem-remainContentRichText img") || []
             imgs.forEach((img) => {
                 lex.push({
                     type: TokenType.Figure,
@@ -243,18 +257,18 @@ export default async (dom: HTMLElement, button?: string, event?: Event): Promise
     const dealComments = async () => {
         try {
             if (getCommentSwitch(dom)) {
-                let p = dom.closest('.ContentItem') || dom.closest('.Post-content')
-                let openComment = p.querySelector(".Comments-container")
+                let p = dom.closest('.ContentItem') || dom.closest('.Post-content') as HTMLElement
+                let openComment = p?.querySelector(".Comments-container")
                 let itemId = type + url.split('/').pop()
                 let tip = ''
 
-                if (openComment && openComment.querySelector('.css-189h5o3')) {
-                    let t = '**' + openComment.querySelector('.css-189h5o3').textContent + '**' //评论区已关闭|暂无评论
+                if (openComment && openComment?.querySelector('.css-189h5o3')) {
+                    let t = '**' + (openComment.querySelector('.css-189h5o3')?.textContent || '') + '**' //评论区已关闭|暂无评论
                     if (button == 'text') commentText = t
                     else zip.file("comments.md", t)
                 }
                 else {
-                    if (openComment && openComment.querySelector('.css-1tdhe7b')) tip = '**评论内容由作者筛选后展示**\n\n'
+                    if (openComment && openComment?.querySelector('.css-1tdhe7b')) tip = '**评论内容由作者筛选后展示**\n\n'
 
                     // @ts-ignore 
                     let commentsData = window.ArticleComments[itemId]?.comments as Map<string, object>
@@ -278,7 +292,7 @@ export default async (dom: HTMLElement, button?: string, event?: Event): Promise
                                     hideObsidianModal()
                                     return alert('已【暂存此页评论】，由于这次是自定义文件夹保存，请再次手动保存文件。')
                                 }
-                                (p.querySelector(`.zhihubackup-wrap .to-${button}`) as HTMLElement).click()
+                                (p?.querySelector(`.zhihubackup-wrap .to-${button}, .zhcollect-minimal-btns .to-${button}`) as HTMLElement)?.click()
                             }, 1900)
                             return 'return'
                         }
@@ -311,7 +325,14 @@ export default async (dom: HTMLElement, button?: string, event?: Event): Promise
     }
 
 
-    if (button == 'copy') {
+    if (button == 'copy' || button == 'copy_context' || button == 'copy_content') {
+        let includeContext = button == 'copy_context';
+        if (button == 'copy' || button == 'copy_context' || button == 'copy_content') {
+            try {
+                // @ts-ignore
+                includeContext = GM_getValue("copy_save_title", true);
+            } catch (e) {}
+        }
         try {
             // @ts-ignore
             var copy_save_fm = GM_getValue("copy_save_fm"),
@@ -321,7 +342,7 @@ export default async (dom: HTMLElement, button?: string, event?: Event): Promise
             console.warn(e)
         }
         md = TOC ? TOC.concat(parser(lex)) : parser(lex)
-        if (type == "pin" && dom.closest('.PinItem').querySelector(".PinItem-content-originpin")) {
+        if (type == "pin" && dom.closest('.PinItem')?.querySelector(".PinItem-content-originpin")) {
             md = md.concat(originPinMD) //解决保存转发的想法异常
         }
         if (copy_save_fm) {
@@ -332,10 +353,13 @@ export default async (dom: HTMLElement, button?: string, event?: Event): Promise
             commentText ? commentText = '\n\n---\n\n## 评论\n\n' + commentText : 0
             md.push(commentText)
         }
-        if (type != 'pin' && !copy_save_fm)
-            return { textString: [title].concat(md).join('\n\n') }//复制内容增加标题
-        else
-            return { textString: md.join('\n\n') }
+        let bodyText = md.join('\n\n');
+        if (button === 'copy_context') {
+            let header = getHeaderMarkdown(dom, scene, type);
+            return { textString: header + bodyText };
+        } else {
+            return { textString: bodyText };
+        }
     }
     // ============================以下只有 text 或 zip 2种情况===========================
 
@@ -343,7 +367,7 @@ export default async (dom: HTMLElement, button?: string, event?: Event): Promise
         if (await dealComments() == 'return') return;
         commentText ? commentText = '\n\n---\n\n## 评论\n\n' + commentText : 0
         let md2: string[] = []
-        if (type == "pin" && dom.closest('.PinItem').querySelector(".PinItem-content-originpin")) {
+        if (type == "pin" && dom.closest('.PinItem')?.querySelector(".PinItem-content-originpin")) {
             md2 = originPinMD
         }
         return {
@@ -356,7 +380,7 @@ export default async (dom: HTMLElement, button?: string, event?: Event): Promise
         //对lex的再处理，保存资产，并将lex中链接改为本地
         var { zip, localLex } = await savelex(lex)
         if (await dealComments() == 'return') return;
-        if (type == "pin" && dom.closest('.PinItem').querySelector(".PinItem-content-originpin")) {
+        if (type == "pin" && dom.closest('.PinItem')?.querySelector(".PinItem-content-originpin")) {
             md = parser(localLex).concat(md)
         }
         else md = parser(localLex)

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,23 +6,77 @@ import { getCommentSwitch } from "./core/utils"
 import { mountParseComments } from "./core/parseComments"
 import { selectObsidianVault, saveFile } from "./core/obsidianSaver";
 import { showToast } from './core/toast';
-/**
- * 适配复杂的想法：转发、带卡片链接、带@
- * 页：推送页，个人/机构主页，回答页，问题页，文章页，想法页，收藏夹页，搜索结果页
- */
 
 // @grant        GM_setValue
 // @grant        GM_getValue
-// @grant    GM_registerMenuCommand
-// @grant    GM_unregisterMenuCommand
+// @grant        GM_registerMenuCommand
+// @grant        GM_unregisterMenuCommand
+// @grant        GM_setClipboard
+
+const copyToClipboard = (text: string): boolean => {
+    try {
+        // @ts-ignore
+        if (typeof GM_setClipboard !== "undefined") {
+            // @ts-ignore
+            GM_setClipboard(text, "text");
+            return true;
+        }
+    } catch (e) {}
+    try {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text);
+            return true;
+        }
+    } catch (e) {}
+    try {
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+        return true;
+    } catch (e) {}
+    return false;
+};
 
 /**
- * 油猴按钮
+ * 油猴按钮 - 保留所有原生设置
  */
 function registerBtn() {
     try {
         // @ts-ignore
-        let skipEmpty = GM_registerMenuCommand(
+        let uiMode = GM_getValue("ui_mode", "minimal");
+        // @ts-ignore
+        GM_registerMenuCommand(
+            `🎨 UI界面模式：${uiMode === 'minimal' ? '【老版极简居中】(点击切换新版)' : '【新版增强侧边栏】(点击切换老版)'}`,
+            function () {
+                let nextMode = uiMode === 'minimal' ? 'full' : 'minimal';
+                // @ts-ignore
+                GM_setValue("ui_mode", nextMode);
+                alert(`已切换为：${nextMode === 'minimal' ? '老版极简居中 UI' : '新版增强侧边栏 UI'}\n刷新页面后生效。`);
+                location.reload();
+            }
+        );
+
+        // @ts-ignore
+        let sidebarTriggerMode = GM_getValue("sidebar_trigger_mode", "hover_content");
+        // @ts-ignore
+        GM_registerMenuCommand(
+            `🔘 侧边栏展开方式：${sidebarTriggerMode === 'chevron' ? '【Chevron图标触发】(点击切换为【鼠标悬停正文】)' : '【鼠标悬停正文触发(原版)】(点击切换为【Chevron图标】)'}`,
+            function () {
+                let nextMode = sidebarTriggerMode === 'chevron' ? 'hover_content' : 'chevron';
+                // @ts-ignore
+                GM_setValue("sidebar_trigger_mode", nextMode);
+                alert(`已切换为：${nextMode === 'chevron' ? 'Chevron 图标触发模式' : '鼠标悬停正文触发模式 (原版)'}\n刷新页面后生效。`);
+                location.reload();
+            }
+        );
+
+        // @ts-ignore
+        GM_registerMenuCommand(
             "（推荐）解析时跳过空白段落",
             function () {
                 // @ts-ignore
@@ -31,12 +85,12 @@ function registerBtn() {
                 if (c) {
                     // @ts-ignore
                     GM_setValue("skip_empty_p", true)
-                    // @ts-ignore
                 } else GM_setValue("skip_empty_p", false)
             }
         )
+
         // @ts-ignore
-        let menuFM = GM_registerMenuCommand(
+        GM_registerMenuCommand(
             "复制内容时添加fm元信息",
             function () {
                 // @ts-ignore
@@ -44,11 +98,11 @@ function registerBtn() {
                 !ac ? c = confirm("复制内容时，添加 frontmatter 信息，就像下载为纯文本的时候一样。你是否继续？") : alert('已取消复制添加fm')
                 // @ts-ignore
                 c ? GM_setValue("copy_save_fm", true) : GM_setValue("copy_save_fm", false)
-                //alert(GM_getValue("copy_save_fm"))
             }
         )
+
         // @ts-ignore
-        let menuSaveCM = GM_registerMenuCommand(
+        GM_registerMenuCommand(
             "复制内容时同时复制评论",
             function () {
                 // @ts-ignore
@@ -56,11 +110,11 @@ function registerBtn() {
                 !ns ? c = confirm("启用后，复制时也会复制评论，就像直接复制了下载的纯文本。你是否继续？") : alert('已取消复制评论')
                 // @ts-ignore
                 c ? GM_setValue("copy_save_cm", true) : GM_setValue("copy_save_cm", false)
-                //alert(GM_getValue("copy_save_cm"))
             }
         )
+
         // @ts-ignore
-        let menuMergeCM = GM_registerMenuCommand(
+        GM_registerMenuCommand(
             "下载zip时合并正文与评论",
             function () {
                 // @ts-ignore
@@ -68,11 +122,11 @@ function registerBtn() {
                 !ns ? c = confirm("启用后，下载zip时会合并正文与评论到一个文件中。你是否继续？") : alert('已取消合并')
                 // @ts-ignore
                 c ? GM_setValue("zip_merge_cm", true) : GM_setValue("zip_merge_cm", false)
-                //alert(GM_getValue("zip_merge_cm"))
             }
         )
+
         // @ts-ignore
-        let menuSaveImg = GM_registerMenuCommand(
+        GM_registerMenuCommand(
             "复制与下载纯文本时不保存图片",
             function () {
                 // @ts-ignore
@@ -80,11 +134,11 @@ function registerBtn() {
                 !ns ? c = confirm("启用后，复制、存文本时将所有图片替换为“[图片]”，不影响存zip。你是否继续？") : alert('已取消不存图')
                 // @ts-ignore
                 c ? GM_setValue("no_save_img", true) : GM_setValue("no_save_img", false)
-                //alert(GM_getValue("no_save_img"))
             }
         )
+
         // @ts-ignore
-        let menuFilename = GM_registerMenuCommand(
+        GM_registerMenuCommand(
             "自定义保存后的文件名格式",
             function () {
                 // @ts-ignore
@@ -94,7 +148,6 @@ function registerBtn() {
                 )
                 // @ts-ignore
                 GM_setValue("edit_Filename", fm)
-                //alert(GM_getValue("edit_Filename"))
             }
         )
     } catch (e) {
@@ -103,9 +156,54 @@ function registerBtn() {
 }
 registerBtn()
 
-const ButtonContainer = document.createElement("div")
-ButtonContainer.classList.add("zhihubackup-wrap")
-ButtonContainer.innerHTML = `<div class="zhihubackup-container">
+const getUIMode = (): 'minimal' | 'full' => {
+    try {
+        // @ts-ignore
+        return GM_getValue("ui_mode", "minimal");
+    } catch (e) {
+        return "minimal";
+    }
+};
+
+const getSidebarTriggerMode = (): 'hover_content' | 'chevron' => {
+    try {
+        // @ts-ignore
+        return GM_getValue("sidebar_trigger_mode", "hover_content");
+    } catch (e) {
+        return "hover_content";
+    }
+};
+
+const renderContainerHTML = (): string => {
+    const isMinimal = getUIMode() === 'minimal';
+    if (isMinimal) {
+        return `<div class="zhcollect-minimal-btns">
+    <button class="to-copy-context zhcollect-btn" style="border-radius:1em 0 0 1em;padding-left:.4em;">复制标题+正文</button>
+    <button class="to-copy-content zhcollect-btn" style="border-radius:0 1em 1em 0;padding-right:.4em;">复制正文</button>
+</div>`;
+    }
+    const isChevronMode = getSidebarTriggerMode() === 'chevron';
+    if (isChevronMode) {
+        return `<div class="zhihubackup-sticky-box">
+    <div class="zhihubackup-container">
+        <button class="to-copy Button VoteButton">复制为Markdown</button>
+        <button class="to-zip Button VoteButton">下载为 ZIP</button>
+        <button class="to-text Button VoteButton">下载为纯文本</button>
+        <button class="to-png Button VoteButton">剪藏为 PNG</button>
+        <button class="to-obsidian Button VoteButton">
+        <svg style="width: 2em;height: 2em;width: 1.5em;height: 1.5em;opacity: 0.6;vertical-align: sub;" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M19.355 18.538a68.967 68.959 0 0 0 1.858-2.954a.81.81 0 0 0-.062-.9c-.516-.685-1.504-2.075-2.042-3.362c-.553-1.321-.636-3.375-.64-4.377a1.7 1.7 0 0 0-.358-1.05l-3.198-4.064a4 4 0 0 1-.076.543c-.106.503-.307 1.004-.536 1.5c-.134.29-.29.6-.446.914l-.31.626c-.516 1.068-.997 2.227-1.132 3.59c-.124 1.26.046 2.73.815 4.481q.192.016.386.044a6.36 6.36 0 0 1 3.326 1.505c.916.79 1.744 1.922 2.415 3.5zM8.199 22.569q.11.019.22.02c.78.024 2.095.092 3.16.29c.87.16 2.593.64 4.01 1.055c1.083.316 2.198-.548 2.355-1.664c.114-.814.33-1.735.725-2.58l-.01.005c-.67-1.87-1.522-3.078-2.416-3.849a5.3 5.3 0 0 0-2.778-1.257c-1.54-.216-2.952.19-3.84.45c.532 2.218.368 4.829-1.425 7.531zM5.533 9.938q-.035.15-.098.29L2.82 16.059a1.6 1.6 0 0 0 .313 1.772l4.116 4.24c2.103-3.101 1.796-6.02.836-8.3c-.728-1.73-1.832-3.081-2.55-3.831zM9.32 14.01c.615-.183 1.606-.465 2.745-.534c-.683-1.725-.848-3.233-.716-4.577c.154-1.552.7-2.847 1.235-3.95q.17-.35.328-.664c.149-.297.288-.577.419-.86c.217-.47.379-.885.46-1.27c.08-.38.08-.72-.014-1.043c-.095-.325-.297-.675-.68-1.06a1.6 1.6 0 0 0-1.475.36l-4.95 4.452a1.6 1.6 0 0 0-.513.952l-.427 2.83c.672.59 2.328 2.316 3.335 4.711q.136.317.253.653"></path></svg>
+        保存到<br>指定文件夹</button>
+        <div class="Button VoteButton" style="display: inline-block;box-sizing: border-box;overflow: hidden;">
+            <textarea class="to-remark" type="text" placeholder="添加备注" style="width: 100%;" maxlength="60"></textarea>
+        </div>
+        <div class="Button VoteButton" style="display: inline-block;box-sizing: border-box;">
+            <label><input type="checkbox" checked class="to-cm"> 保存评论</label>
+        </div>
+    </div>
+    <div class="zhihubackup-trigger" title="展开工具栏"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"></polyline></svg></div>
+</div>`;
+    }
+    return `<div class="zhihubackup-container">
     <button class="to-copy Button VoteButton">复制为Markdown</button>
     <button class="to-zip Button VoteButton">下载为 ZIP</button>
     <button class="to-text Button VoteButton">下载为纯文本</button>
@@ -118,11 +216,29 @@ ButtonContainer.innerHTML = `<div class="zhihubackup-container">
     </div>
     <div class="Button VoteButton" style="display: inline-block;box-sizing: border-box;">
         <label><input type="checkbox" checked class="to-cm"> 保存评论</label>
-    </div>`
+    </div>
+</div>`;
+};
+
+const ButtonContainer = document.createElement("div")
+if (getUIMode() === 'full') {
+    ButtonContainer.classList.add("zhihubackup-wrap")
+}
+ButtonContainer.innerHTML = renderContainerHTML()
+
+function throttle(func: Function, wait = 1000) {
+    let timer: any = null
+    return function (this: any, ...args: any[]) {
+        if (!timer) {
+            func.apply(this, args)
+            timer = setTimeout(() => {
+                timer = null
+            }, wait)
+        }
+    }
+}
 
 const main = async () => {
-
-    //console.log("Starting…")
     const RichTexts = Array.from(document.querySelectorAll(".RichText")) as HTMLElement[]
     for (let RichText of RichTexts) {
         try {
@@ -131,278 +247,350 @@ const main = async () => {
                 textString?: string,
                 title: string,
             }
-            //console.log(RichText)
-            if (RichText.parentElement.classList.contains("Editable")) continue
+            if (RichText.parentElement && RichText.parentElement.classList.contains("Editable")) continue
             if (window.location.hostname.includes('zhuanlan')) {
-                if (RichText.closest('.Post-Main').querySelector(".zhihubackup-container")) continue
+                if (RichText.closest('.Post-Main')?.querySelector(".zhcollect-minimal-btns, .zhihubackup-container")) continue
             }
             else {
                 if (RichText.closest('.PinItem')) {
-                    if (!RichText.closest('.RichContent-inner')) continue//每个带图想法有3个RichText，除掉图、假转发
-                    //if (RichText.children[0].classList.contains("Image-Wrapper-Preview")) continue
-                    if (RichText.closest('.PinItem-content-originpin')) continue//被转发想法
+                    if (!RichText.closest('.RichContent-inner')) continue
+                    if (RichText.closest('.PinItem-content-originpin')) continue
                 }
-                if (RichText.closest('.RichContent').querySelector(".zhihubackup-container")) continue
+                if (RichText.closest('.RichContent')?.querySelector(".zhcollect-minimal-btns, .zhihubackup-container")) continue
                 const richInner = RichText.closest('.RichContent-inner')
-                if (richInner && richInner.querySelector(".ContentItem-more")) continue//未展开
-                if (RichText.closest('.RichContent').querySelector(".ContentItem-expandButton")) continue
-                //if (RichText.textContent.length == 0) continue
+                if (richInner && richInner.querySelector(".ContentItem-more")) continue
+                if (RichText.closest('.RichContent')?.querySelector(".ContentItem-expandButton")) continue
             }
+
             const aButtonContainer = ButtonContainer.cloneNode(true) as HTMLDivElement
 
-            //父级
             let parent_dom = RichText.closest('.List-item') ||
                 RichText.closest('.Post-content') ||
                 RichText.closest('.PinItem') ||
                 RichText.closest('.CollectionDetailPageItem') ||
-                RichText.closest('.Card') as HTMLElement
-            if (parent_dom.querySelector('.Catalog')) {
-                (aButtonContainer.firstElementChild as HTMLElement).style.position = 'fixed';
-                (aButtonContainer.firstElementChild as HTMLElement).style.top = 'unset';
-                (aButtonContainer.firstElementChild as HTMLElement).style.bottom = '60px'
+                RichText.closest('.Card') as HTMLElement || RichText
+
+            if (getUIMode() === 'full') {
+                if (getSidebarTriggerMode() === 'chevron') {
+                    aButtonContainer.classList.add('zhihubackup-chevron-mode');
+                }
+                const containerEl = aButtonContainer.querySelector('.zhihubackup-container') as HTMLElement;
+                if (parent_dom.querySelector && parent_dom.querySelector('.Catalog') && containerEl) {
+                    containerEl.style.position = 'fixed';
+                    containerEl.style.top = 'unset';
+                    containerEl.style.bottom = '60px'
+                }
+                let p = RichText.closest('.RichContent') || RichText.closest('.Post-RichTextContainer') as HTMLElement || RichText
+                p.prepend(aButtonContainer)
+
+                const closeAllSidebars = (except?: HTMLElement) => {
+                    document.querySelectorAll('.zhihubackup-wrap.is-open').forEach((el) => {
+                        if (el !== except) el.classList.remove('is-open');
+                    });
+                };
+
+                // Chevron trigger: hover or click to open sidebar, single active panel globally
+                const trigger = aButtonContainer.querySelector('.zhihubackup-trigger') as HTMLElement;
+                if (trigger) {
+                    trigger.addEventListener('mouseenter', () => {
+                        closeAllSidebars(aButtonContainer);
+                        aButtonContainer.classList.add('is-open');
+                    });
+                    trigger.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        const wasOpen = aButtonContainer.classList.contains('is-open');
+                        closeAllSidebars();
+                        if (!wasOpen) {
+                            aButtonContainer.classList.add('is-open');
+                        }
+                    });
+                    aButtonContainer.addEventListener('mouseleave', () => {
+                        aButtonContainer.classList.remove('is-open');
+                    });
+                }
+            } else {
+                RichText.prepend(aButtonContainer)
             }
-            let p = RichText.closest('.RichContent') || RichText.closest('.Post-RichTextContainer') as HTMLElement
-            p.prepend(aButtonContainer)
 
-            // 为 textarea 添加事件监听器，阻止事件冒泡，确保可以正常输入
             const textareaRemark = parent_dom.querySelector(".to-remark") as HTMLTextAreaElement
-            textareaRemark.addEventListener("click", (e) => {
-                e.stopPropagation()
-                e.preventDefault()
-                textareaRemark.focus()
-            }, true) // 使用捕获阶段
+            if (textareaRemark) {
+                textareaRemark.addEventListener("click", (e) => {
+                    e.stopPropagation()
+                    e.preventDefault()
+                    textareaRemark.focus()
+                }, true)
+            }
 
-            const ButtonMarkdown = parent_dom.querySelector(".to-copy")
-            ButtonMarkdown.addEventListener("click", throttle(async (event: Event) => {
-                try {
-                    const res = await dealItem(RichText, 'copy', event)
-                    if (!res) return;// 取消保存
-                    result = {
-                        textString: res.textString,
-                        title: res.title,
-                    }
-                    /*console.log(result.markdown.join("\n\n"))*/
-                    navigator.clipboard.writeText(result.textString)
-                    ButtonMarkdown.innerHTML = "复制成功✅"
-                    setTimeout(() => {
-                        ButtonMarkdown.innerHTML = "复制为Markdown"
-                    }, 3000)
-                } catch (e) {
-                    console.log(e)
-                    ButtonMarkdown.innerHTML = "发生错误❌<br>请打开控制台查看"
-                    setTimeout(() => {
-                        ButtonMarkdown.innerHTML = "复制为Markdown"
-                    }, 3000)
-                }
-            }))
-
-            const ButtonZip = parent_dom.querySelector(".to-zip")
-            ButtonZip.addEventListener("click", throttle(async (event: Event) => {
-                try {
-                    ButtonZip.innerHTML = "下载中……"
-                    const res = await dealItem(RichText, 'zip', event)
-                    if (!res)
-                        return ButtonZip.innerHTML = "下载为 ZIP";// 取消保存
-                    result = {
-                        zip: res.zip,
-                        title: res.title,
-                    }
-                    const blob = await result.zip.generateAsync({ type: "blob" })
-                    saveAs(blob, result.title + ".zip")
-                    ButtonZip.innerHTML = "下载成功✅<br>请看下载记录"
-                    setTimeout(() => {
-                        ButtonZip.innerHTML = "下载为 ZIP"
-                    }, 5000)
-                } catch (e) {
-                    console.log(e)
-                    ButtonZip.innerHTML = "发生错误❌<br>请打开控制台查看"
-                    setTimeout(() => {
-                        ButtonZip.innerHTML = "下载为 ZIP"
-                    }, 5000)
-                }
-            },))
-
-            const ButtonPNG = parent_dom.querySelector(".to-png")
-            ButtonPNG.addEventListener("click", throttle(async (event: Event) => {
-                try {
-                    const res = await dealItem(RichText, 'png', event)
-                    if (!res) return;// 取消保存
-                    result = {
-                        title: res.title,
-                    }
-
-                    let clip = parent_dom
-                    clip.classList.add("to-screenshot")
-                    let saveCM = getCommentSwitch(RichText)
-                    !saveCM ? clip.classList.add("no-cm") : 0
-                    let svgDefs = document.querySelector("#MathJax_SVG_glyphs") as HTMLElement
-                    svgDefs ? svgDefs.style.visibility = "visible" : 0
-
-                    domToPng(clip, {
-                        backgroundColor: "#fff",
-                        filter(el) {
-                            if ((el as HTMLElement).tagName == 'DIV' && (el as HTMLElement).classList.contains('zhihubackup-wrap')) return false
-                            else return true
-                        },
-                    }).then((dataUrl: any) => {
-                        const link = document.createElement('a')
-                        link.download = result.title + ".png"
-                        link.href = dataUrl
-                        link.click()
-                        setTimeout(() => {
-                            clip.classList.remove("to-screenshot")
-                            !saveCM ? clip.classList.remove("no-cm") : 0
-                            //svgDefs2.remove()
-                            ButtonPNG.innerHTML = "剪藏为 PNG"
-                        }, 5000)
-                    })
-                    ButtonPNG.innerHTML = "请稍待片刻✅<br>查看下载记录"
-                } catch (e) {
-                    console.log(e)
-                    ButtonPNG.innerHTML = "发生错误❌<br>请打开控制台查看"
-                    setTimeout(() => {
-                        ButtonPNG.innerHTML = "剪藏为 PNG"
-                    }, 5000)
-                }
-            }))
-
-            const ButtonText = parent_dom.querySelector(".to-text")
-            ButtonText.addEventListener("click", throttle(async (event: Event) => {
-                try {
-                    const res = await dealItem(RichText, 'text', event)
-                    if (!res) return;// 取消保存
-                    result = {
-                        textString: res.textString,
-                        title: res.title,
-                    }
-                    const blob = new Blob([result.textString], { type: 'text/plain' })
-                    saveAs(blob, result.title + ".md")
-                    ButtonText.innerHTML = "下载成功✅<br>请看下载记录，以文本方式打开"
-                    setTimeout(() => {
-                        ButtonText.innerHTML = "下载为纯文本"
-                    }, 5000)
-                } catch (e) {
-                    console.log(e)
-                    ButtonText.innerHTML = "发生错误❌<br>请打开控制台查看"
-                    setTimeout(() => {
-                        ButtonText.innerHTML = "下载为纯文本"
-                    }, 5000)
-                }
-            }))
-
-            const ButtonObsidian = parent_dom.querySelector(".to-obsidian")
-            ButtonObsidian.addEventListener("click", throttle(async (event: Event) => {
-                try {
-                    let saveType = await selectObsidianVault()
-                    if (!saveType) return;// 取消保存
-
-                    if (saveType == 'text') {
-                        const res = await dealItem(RichText, 'text')
-                        if (!res) return;// 取消保存
-                        result = {
-                            textString: res.textString,
-                            title: res.title,
+            const bindCopyBtn = (selector: string, mode: string, defaultText: string) => {
+                const btn = parent_dom.querySelector(selector) as HTMLElement
+                if (!btn) return
+                btn.addEventListener("click", throttle(async (event: Event) => {
+                    try {
+                        const res = await dealItem(RichText, mode, event)
+                        if (!res || !res.textString) {
+                            btn.innerHTML = "发生错误❌"
+                            setTimeout(() => { btn.innerHTML = defaultText }, 2000)
+                            return
                         }
-                        await saveFile(result, saveType as any)
+                        copyToClipboard(res.textString)
+                        btn.innerHTML = "复制成功✅"
+                        setTimeout(() => { btn.innerHTML = defaultText }, 1500)
+                    } catch (e) {
+                        console.error(e)
+                        btn.innerHTML = "发生错误❌"
+                        setTimeout(() => { btn.innerHTML = defaultText }, 2000)
                     }
-                    else if (saveType.slice(0, 3) == 'zip') {
-                        const res = await dealItem(RichText, 'zip')
-                        if (!res) return;// 取消保存
-                        result = {
-                            zip: res.zip,
-                            title: res.title,
+                }))
+            }
+
+            bindCopyBtn(".to-copy-context", "copy_context", "复制标题+正文")
+            bindCopyBtn(".to-copy-content", "copy_content", "复制正文")
+            bindCopyBtn(".to-copy", "copy_content", "复制为Markdown")
+
+            const bindSaveBtn = (selector: string, saveType: string) => {
+                const btn = parent_dom.querySelector(selector) as HTMLElement
+                if (!btn) return
+                btn.addEventListener("click", throttle(async (event: Event) => {
+                    try {
+                        let result: {
+                            zip?: JSZip,
+                            textString?: string,
+                            title: string,
                         }
-                        await saveFile(result, saveType as any)
-                    }
-                    else if (saveType == 'png') {
-                        const res = await dealItem(RichText, 'png')
-                        if (!res) return;// 取消保存
-
-                        let clip = parent_dom
-                        clip.classList.add("to-screenshot")
-                        let saveCM = getCommentSwitch(RichText)
-                        !saveCM ? clip.classList.add("no-cm") : 0
-                        let svgDefs = document.querySelector("#MathJax_SVG_glyphs") as HTMLElement
-                        svgDefs ? svgDefs.style.visibility = "visible" : 0
-
-                        domToPng(clip, {
-                            backgroundColor: "#fff",
-                            filter(el) {
-                                if ((el as HTMLElement).tagName == 'DIV' && (el as HTMLElement).classList.contains('zhihubackup-wrap')) return false
-                                else return true
-                            },
-                        }).then(async (dataUrl: any) => {
+                        if (saveType.slice(0, 4) == 'text') {
+                            const res = await dealItem(RichText, 'text')
+                            if (!res) return
                             result = {
-                                textString: dataUrl,
+                                textString: res.textString,
                                 title: res.title,
                             }
-                            clip.classList.remove("to-screenshot")
-                            !saveCM ? clip.classList.remove("no-cm") : 0
                             await saveFile(result, saveType as any)
-                        })
+                        }
+                        else if (saveType.slice(0, 3) == 'zip') {
+                            const res = await dealItem(RichText, 'zip')
+                            if (!res) return
+                            result = {
+                                zip: res.zip,
+                                title: res.title,
+                            }
+                            await saveFile(result, saveType as any)
+                        }
+                        else if (saveType == 'png') {
+                            const res = await dealItem(RichText, 'png')
+                            if (!res) return
+
+                            let clip = parent_dom
+                            clip.classList.add("to-screenshot")
+                            let saveCM = getCommentSwitch(RichText)
+                            !saveCM ? clip.classList.add("no-cm") : 0
+                            let svgDefs = document.querySelector("#MathJax_SVG_glyphs") as HTMLElement
+                            svgDefs ? svgDefs.style.visibility = "visible" : 0
+
+                            domToPng(clip, {
+                                backgroundColor: "#fff",
+                                filter(el) {
+                                    if ((el as HTMLElement).tagName == 'DIV' && (el as HTMLElement).classList.contains('zhihubackup-wrap')) return false
+                                    else return true
+                                },
+                            }).then(async (dataUrl: any) => {
+                                result = {
+                                    textString: dataUrl,
+                                    title: res.title,
+                                }
+                                clip.classList.remove("to-screenshot")
+                                !saveCM ? clip.classList.remove("no-cm") : 0
+                                await saveFile(result, saveType as any)
+                            })
+                        }
+                    } catch (e) {
+                        console.log(e)
+                        alert('发生错误❌请打开控制台查看\n你可以关闭窗口后再试一次！')
                     }
-                } catch (e) {
-                    console.log(e)
-                    alert('发生错误❌请打开控制台查看\n你可以关闭窗口后再试一次！')
-                }
-            }))
+                }))
+            }
 
+            bindSaveBtn(".to-zip", "zip")
+            bindSaveBtn(".to-text", "text")
+            bindSaveBtn(".to-png", "png")
+
+            const ButtonObsidian = parent_dom.querySelector(".to-obsidian")
+            if (ButtonObsidian) {
+                ButtonObsidian.addEventListener("click", throttle(async (event: Event) => {
+                    try {
+                        selectObsidianVault(async (vault: string, folder: string) => {
+                            const res = await dealItem(RichText, 'obsidian', event)
+                            if (!res) return
+                            if (res.zip) {
+                                saveFile(res.zip, vault, folder, res.title)
+                            } else if (res.textString) {
+                                const zip = new JSZip()
+                                zip.file("index.md", res.textString)
+                                saveFile(zip, vault, folder, res.title)
+                            }
+                            showToast('✅ 导出成功！')
+                        })
+                    } catch (e) {
+                        console.error(e)
+                        showToast('❌ 导出失败！')
+                    }
+                }))
+            }
         } catch (e) {
-            console.log(e)
+            console.error(e)
         }
     }
 }
 
-function throttle(fn: Function, delay: number = 2000) {
-    let flag = true
-    return function (this: any, ...args: any[]) {  // 使用剩余参数接收所有参数
-        if (flag) {
-            flag = false
-            setTimeout(() => {
-                flag = true
-            }, delay)
-            return fn.apply(this, args);  // 通过 apply 传递参数和 this
-        }
-    }
-}
+mountParseComments()
 
 setTimeout(() => {
-    let node = document.createElement("style")//!important
+    let node = document.createElement("style")
     node.appendChild(document.createTextNode(`
+    /* ========== Minimal Mode: Joined Capsule Buttons ========== */
+    .zhcollect-minimal-btns {
+        user-select: none;
+    }
+    .zhcollect-btn {
+        width: 120px;
+        height: 2em;
+        background-color: rgba(85, 85, 85, 0.9);
+        color: white;
+        outline: none;
+        cursor: pointer;
+        border: none;
+        border-radius: 1em;
+        margin: 0 .2em 1em .2em;
+        font-size: .8em;
+        z-index: 999;
+    }
+    .zhcollect-btn:hover {
+        background-color: rgba(60, 60, 60, 0.95);
+    }
+
+    /* ========== Full Mode: Sidebar Layout Architecture ========== */
     .RichContent {
         position: relative;
     }
     .zhihubackup-wrap {
-        opacity: 0;
-        pointer-events: none;
-        transition: opacity 0.5s;
         position: absolute;
-        left: -10em;
+        left: -9.5em;
         top: -100px;
         height: 100%;
         min-height: 200px;
         user-select: none;
-        width: 12em;
+        width: 9.5em; /* 保证整体靠左侧外边距展开，绝不占用正文侧向空间 */
     }
-    .RichContent:hover .zhihubackup-wrap,
-    .ContentItem:hover .zhihubackup-wrap,
-    .Post-content:hover .zhihubackup-wrap,
-    .Post-RichTextContainer:hover .zhihubackup-wrap,
-    .zhihubackup-wrap:hover {
-        opacity: 1;
-        pointer-events: initial;
+
+    /* CRITICAL FIX: Allow Card containers to show overflowing sidebars without clipping or overlapping text! */
+    .Card:has(.zhihubackup-wrap) {
+        overflow: visible !important;
     }
-    .zhihubackup-container {
+
+    /* Default: Native Hover Mode */
+    .zhihubackup-wrap:not(.zhihubackup-chevron-mode) {
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+    }
+    .RichContent:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .ContentItem:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .AnswerItem:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .ArticleItem:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .PinItem:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .Post-content:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .Post-RichTextContainer:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .List-item:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .Card:hover .zhihubackup-wrap:not(.zhihubackup-chevron-mode),
+    .zhihubackup-wrap:not(.zhihubackup-chevron-mode):hover {
+        opacity: 1 !important;
+        pointer-events: initial !important;
+    }
+    .zhihubackup-wrap:not(.zhihubackup-chevron-mode) .zhihubackup-container {
         position: sticky;
         top: 120px;
-        /*display: flex;
-        flex-direction: column;
-        justify-content: space-around;
-        height: 22em;*/
         width: min-content;
         max-width: 8em;
         z-index: 2;
     }
+
+    /* Chevron Mode Sticky Box */
+    .zhihubackup-chevron-mode .zhihubackup-sticky-box {
+        position: sticky;
+        top: 200px; /* 悬浮吸顶高度（低于知乎顶部导航栏） */
+        display: flex;
+        flex-direction: row; /* 正向 Row：左侧为功能菜单，右侧紧贴正文的是 Chevron 按钮 */
+        align-items: flex-start;
+        justify-content: flex-end; /* 靠右对齐：触发按钮紧贴回答正文左边界 */
+        gap: 8px;
+        width: 100%;
+    }
+    .zhihubackup-chevron-mode .zhihubackup-trigger {
+        position: relative;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: rgba(60, 60, 60, 0.7);
+        background: rgba(255, 255, 255, 0.85);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        border: 1px solid rgba(0, 0, 0, 0.08);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        transition: opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+                    background 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+                    transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+                    box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+                    color 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+        opacity: 0.35; /* 默认低透明度常驻浮现，能看清按钮位置但绝不刺眼 */
+        z-index: 3;
+        pointer-events: auto;
+        box-sizing: border-box;
+        width: 24px;
+        height: 38px;
+        border-radius: 12px;
+        flex-shrink: 0;
+        margin-right: 12px; /* ★ 向左平移12px骑在中线上（一半在卡片内，一半在卡片外） */
+    }
+    .zhihubackup-chevron-mode .zhihubackup-trigger::before {
+        content: '';
+        position: absolute;
+        top: -16px;
+        bottom: -16px;
+        left: -16px;
+        right: -16px;
+        border-radius: inherit;
+    }
+    .zhihubackup-chevron-mode .zhihubackup-trigger svg {
+        transition: transform 0.3s ease;
+    }
+    .zhihubackup-wrap.is-open .zhihubackup-trigger {
+        opacity: 0.85;
+    }
+
+    .zhihubackup-trigger:hover {
+        opacity: 1 !important;
+        background: rgba(255, 255, 255, 0.98);
+        border-color: rgba(23, 114, 246, 0.3);
+        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.14), 0 2px 6px rgba(0, 0, 0, 0.05);
+        transform: scale(1.18);
+        color: #1772f6;
+    }
+
+    .zhihubackup-chevron-mode .zhihubackup-container {
+        position: static;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+    }
+
+    .zhihubackup-wrap.is-open .zhihubackup-container {
+        opacity: 1;
+        pointer-events: auto;
+    }
+    .zhihubackup-wrap.is-open .zhihubackup-trigger svg {
+        transform: rotate(180deg);
+    }
+
     .zhihubackup-container .Button {
         width: 8em;
         margin-bottom: 8px;
@@ -411,7 +599,6 @@ setTimeout(() => {
     }
     .zhihubackup-container input,
     .zhihubackup-container textarea {
-        /*border: 1px solid #777;*/
         background-color: #0000;
         font-size: 14px;
         color: #1772f6;
@@ -436,7 +623,7 @@ setTimeout(() => {
         margin: 0 -20px -10px!important;
     }
     .to-screenshot.Post-content .RichContent-actions {
-        position: initial!important;/*专栏*/
+        position: initial!important;
         box-shadow: unset!important;
     }
     .to-screenshot.Post-content {
@@ -450,12 +637,12 @@ setTimeout(() => {
         align-items: center;
     }
     .to-screenshot.PinItem .RichText>.RichText:has(a[data-first-child]) {
-        display: flex;/*想法-卡片链接*/
+        display: flex;
         flex-direction: column;
         align-items: center;
     }
     .to-screenshot .ContentItem-actions>.ContentItem-actions {
-        margin-top: -10px!important;/*想法*/
+        margin-top: -10px!important;
     }
     .to-screenshot .css-m4psdq{
         opacity: 0;
@@ -486,7 +673,7 @@ setTimeout(() => {
         margin: 0 !important;
     }
     .to-screenshot.PinItem{
-        margin: 16px 0;/*想法增加留白*/
+        margin: 16px 0;
         padding: 0 16px;
         width: 690px;
     }
@@ -494,13 +681,10 @@ setTimeout(() => {
         max-width: 706px!important;
     }
     .to-screenshot .Recommendations-Main{
-        display: none;/*文章推荐阅读*/
+        display: none;
     }
     .to-screenshot .css-kt4t4n{
-        display: none;/*下方黏性评论栏*/
-    }
-    .to-screenshot .zhihubackup-container{
-        /*display: none;*/
+        display: none;
     }
     .RichContent:has(.ContentItem-more) .zhihubackup-wrap,
     .Post-RichTextContainer:has(.ContentItem-more) .zhihubackup-wrap{
@@ -516,12 +700,9 @@ setTimeout(() => {
         opacity: 1;
         pointer-events: initial;
     }
-    .Card:has(.zhihubackup-wrap){
-        overflow: visible!important;
-    }
     `))
     let head = document.querySelector("head")
-    head.appendChild(node)
+    if (head) head.appendChild(node)
 
     if (window.innerWidth < 1275) {
         let node2 = document.createElement("style")
@@ -539,16 +720,14 @@ setTimeout(() => {
             z-index: 2;
         }
         `))
-        head.appendChild(node2)
+        if (head) head.appendChild(node2)
     }
 }, 30)
 
 setTimeout(() => {
     main()
-    mountParseComments()
     // @ts-ignore
     window.zhbf = main
-    // 在window对象上创建存储空间
     // @ts-ignore
     window.ArticleComments = window.ArticleComments || {};
     document.querySelector('.Topstory-tabs')?.addEventListener('click', () => {
@@ -556,11 +735,10 @@ setTimeout(() => {
     })
 }, 300)
 
-let timer: any = null
+let scrollTimer: any = null
 window.addEventListener("scroll", () => {
-    //debounce
-    if (timer) {
-        clearTimeout(timer)
+    if (scrollTimer) {
+        clearTimeout(scrollTimer)
     }
-    timer = setTimeout(main, 1000)
+    scrollTimer = setTimeout(main, 1000)
 })


### PR DESCRIPTION
## 🌟 新增功能与优化 (Features & Improvements)

1. **油猴菜单新增【侧边栏展开方式】切换设置** (\GM_registerMenuCommand\):
   - **\【鼠标悬停正文触发 (原版)】\**（默认）：完全保留并还原原生 \zhihu-backup-collect\ 体验，页面零图标，鼠标悬停回答/文章正文区域即平滑展现侧边栏菜单。
   - **\【Chevron 图标触发】\**：正文左边缘提供常驻 Chevron 胶囊小按钮（半透明骑在中线上）；悬停/点击向左侧外边距平滑展开侧边栏，支持全局唯一侧边栏激活保护（打开新侧边栏时自动关闭其它侧边栏）。

2. **老版极简 UI 按钮样式重构**：
   - 采用标准二合一胶囊设计（两端圆角、居中对齐、单侧悬停高亮），完美避开多脚本协作时的 DOM 冲突。

3. **布局防重叠与溢出修复**：
   - 恢复 \.Card:has(.zhihubackup-wrap) { overflow: visible !important; }\，解决特定知乎卡片模板导致的菜单切边与重叠问题。
   - 补全 \.AnswerItem:hover\, \.ArticleItem:hover\, \.PinItem:hover\ 全站卡片悬停选择器。